### PR TITLE
Prevent Paws::Net::Caller from crashing upon not receiving and object

### DIFF
--- a/lib/Paws/Net/Caller.pm
+++ b/lib/Paws/Net/Caller.pm
@@ -32,7 +32,9 @@ package Paws::Net::Caller {
     );
 
     my $res = $service->handle_response($call_object, $response->{status}, $response->{content}, $response->{headers});
-    if ($res->isa('Paws::Exception')) {
+    if (not ref($res)){
+      return $res;
+    } elsif ($res->isa('Paws::Exception')) {
       $res->throw;
     } else {
       return $res;


### PR DESCRIPTION
Prevent Paws::Net::Caller from crashing upon not receiving and object