### PR TITLE
Fix test failures: some utf8 issues in 10_responses.t 

### DIFF
--- a/t/10_responses.t
+++ b/t/10_responses.t
@@ -57,7 +57,7 @@ sub test_file {
 
     my $res;
     my $passed = lives_ok {
-      my $content = read_file($file);
+      my $content = read_file($file, {binmode => ':utf8'});
       my $unserialized_struct = $service->unserialize_response( $content );
 
       if ($debug){

--- a/t/10_responses/elasticbeanstalk-create-configuration-template.response
+++ b/t/10_responses/elasticbeanstalk-create-configuration-template.response
@@ -36,7 +36,7 @@
         <OptionName>InstanceType</OptionName>
         <Value>t1.micro</Value>
         <Namespace>aws:autoscaling:launchconfiguration</Namespace>
-￼￼￼</member>
+</member>
 <member>
 <OptionName>Statistic</OptionName>
   <Value>Average</Value>
@@ -151,7 +151,7 @@
   <OptionName>PARAM1</OptionName>
   <Value/>
   <Namespace>aws:elasticbeanstalk:application:environment</Namespace>
-￼￼￼</member>
+</member>
 <member>
   <OptionName>MaxSize</OptionName>
   <Value>4</Value>
@@ -206,7 +206,7 @@
   <OptionName>Xms</OptionName>
   <Value>256m</Value>
  <Namespace>aws:elasticbeanstalk:container:tomcat:jvmoptions</Namespace>
-￼￼￼</member>
+</member>
 <member>
 <OptionName>EC2KeyName</OptionName>
         <Value/>


### PR DESCRIPTION
Hi,

There were some unicode related test failures in 10_responses.t. 

From http://www.cpantesters.org/cpan/report/7e730056-40bd-11e5-a85a-e28fcaadd3a7 :

```
 #   Failed test 'Got GeoLocationDetailsList.205.CountryName eq São Tomé and Príncipe from result'
#   at t/10_responses.t line 97.
#          got: 'SÃ£o TomÃ© and PrÃ­ncipe'
#     expected: 'São Tomé and Príncipe'

#   Failed test 'Got GeoLocationDetailsList.15.CountryName eq Åland from result'
#   at t/10_responses.t line 97.
#          got: 'Ãland'
#     expected: 'Åland'

#   Failed test 'Got GeoLocationDetailsList.52.CountryName eq Curaçao from result'
#   at t/10_responses.t line 97.
#          got: 'CuraÃ§ao'
#     expected: 'Curaçao'

#   Failed test 'Got GeoLocationDetailsList.184.CountryName eq Réunion from result'
#   at t/10_responses.t line 97.
#          got: 'RÃ©union'
#     expected: 'Réunion'

#   Failed test 'Got GeoLocationDetailsList.26.CountryName eq Saint Barthélemy from result'
#   at t/10_responses.t line 97.
#          got: 'Saint BarthÃ©lemy'
#     expected: 'Saint Barthélemy'
```
This pull requests slurps the data files with utf8 encoding and removes a few unprintable chars from one of the data files.

Thanks!