### PR TITLE
Make sure all request timestamps are in sync

### DIFF
--- a/lib/Paws/Net/JsonCaller.pm
+++ b/lib/Paws/Net/JsonCaller.pm
@@ -52,10 +52,11 @@ package Paws::Net::JsonCaller {
     $request->uri('/');
     $request->method('POST');
 
+    my @time = gmtime;
     $request->parameters({ Action => $call->_api_call,
                            Version => $self->version,
                            AWSAccessKeyId => $self->access_key,
-                           Timestamp => strftime("%Y-%m-%dT%H:%M:%SZ",gmtime),
+                           Timestamp => strftime("%Y-%m-%dT%H:%M:%SZ",@time),
                         });
     $request->header('X-Amz-Target', sprintf('%s.%s', $self->target_prefix, $call->_api_call));
 
@@ -63,7 +64,7 @@ package Paws::Net::JsonCaller {
     $request->headers->content_type("application/x-amz-json-$j_version");
 
     #$request->header('Content-Encoding', 'amz-1.0');
-    $request->header( 'X-Amz-Date' => strftime( '%Y%m%dT%H%M%SZ', gmtime) );
+    $request->header( 'X-Amz-Date' => strftime( '%Y%m%dT%H%M%SZ', @time ) );
     $request->header( Host => $self->endpoint_host );
 
     my $data = $self->_to_jsoncaller_params($call);

--- a/lib/Paws/Net/V2Signature.pm
+++ b/lib/Paws/Net/V2Signature.pm
@@ -57,7 +57,7 @@ sub sign {
 
     $request->parameters->{ SignatureVersion } = "2";
     $request->parameters->{ SignatureMethod } = "HmacSHA256";
-    $request->parameters->{ Timestamp } = strftime("%Y-%m-%dT%H:%M:%SZ",gmtime);
+    $request->parameters->{ Timestamp } //= strftime("%Y-%m-%dT%H:%M:%SZ",gmtime);
     $request->parameters->{ AWSAccessKeyId } = $self->access_key;
 
     if ($self->session_token) {

--- a/lib/Paws/Net/V4Signature.pm
+++ b/lib/Paws/Net/V4Signature.pm
@@ -8,7 +8,7 @@ package Paws::Net::V4Signature {
   sub sign {
     my ($self, $request) = @_;
 
-    $request->header( Date => strftime( '%Y%m%dT%H%M%SZ', gmtime) );
+    $request->header( Date => $request->header('X-Amz-Date') // strftime( '%Y%m%dT%H%M%SZ', gmtime ) );
     $request->header( Host => $self->endpoint_host );
     if ($self->session_token) {
       $request->header( 'X-Amz-Security-Token' => $self->session_token );


### PR DESCRIPTION
Otherwise the signature can be invalid if the second ticks over
between the X-Amz-Date and Date headers being set, since
Net::Amazon::Signature::V4 only uses Date, but Amazon prefers
X-Amz-Date.

Net::Amazon::Signature::V4 also needs fixing to use X-Amz-Date, but
the patch in https://rt.cpan.org/Public/Bug/Display.html?id=100964
hasn't been applied yet.