### PR TITLE
add support for making S3 calls using temporary credentials

### DIFF
--- a/lib/Paws/Net/S3Signature.pm
+++ b/lib/Paws/Net/S3Signature.pm
@@ -8,6 +8,10 @@ package Paws::Net::S3Signature {
   sub sign {
     my ($self, $request) = @_;
 
+    if ($self->session_token) {
+      $request->header( 'X-Amz-Security-Token' => $self->session_token );
+    }
+
     my $hmac = Digest::HMAC_SHA1->new( $self->secret_key );
     $hmac->add( $request->string_to_sign() );
 


### PR DESCRIPTION
I was getting my requests denied when trying to use Paws::S3 with temporary credential I received from assuming a role.  This fixes it.