### PR TITLE
Remove some unneeded test prereqs

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -43,5 +43,4 @@ on 'test' => sub {
   requires 'File::Slurper';
   requires 'YAML';
   requires 'Test::Class::Moose::Load';
-  requires 'Hash::MD5';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -39,7 +39,6 @@ on 'develop' => sub {
   requires 'Devel::Cover';
 };
 on 'test' => sub {
-  requires 'Data::Printer';
   requires 'File::Slurper';
   requires 'YAML';
   requires 'Test::Class::Moose::Load';

--- a/t/04_credentials.t
+++ b/t/04_credentials.t
@@ -4,7 +4,6 @@ use lib 't/lib';
 use Paws::Credential::Environment;
 use Paws::Credential::InstanceProfile;
 use Paws::Credential::ProviderChain;
-use Data::Printer;
 use Test::More;
 use Test::Exception;
 use Test04::StubUAForMetadata;


### PR DESCRIPTION
- Hash::MD5 is no longer used, so I removed it from test prereqs.
- I couldn't see where Data::Printer was being used in tests, so I removed that too.

Also, I wonder what the problem was with `[Test::Compile]`? Is there something I can fix?  If the compile test was generated as a normal test (not using install mode), then t/01-load.t could be deleted and allow for the removal of Test::Class::Moose as a prerequisite -- this is a rather large distribution with other dependencies and is only being used to load all the classes in the distribution.