### PR TITLE
[WIP] STS Federated Login

### DIFF
--- a/examples/sts-saml.pl
+++ b/examples/sts-saml.pl
@@ -1,0 +1,129 @@
+#!/usr/bin/env perl
+
+use v5.16.2;
+use warnings;
+use Config::INI::Reader;
+use Config::INI::Writer;
+use IO::Prompter;
+use LWP::Authen::Negotiate;
+use LWP::UserAgent;
+use MIME::Base64;
+use Path::Tiny;
+use Paws;
+use Paws::Credential::AssumeRoleWithSAML;
+use Text::Table::Tiny 0.04 'generate_table';
+use URI;
+use XML::XPath;
+
+use syntax 'try';
+
+my $aws_conf_dir   = path($ENV{HOME}, '.aws');
+my $saml_conf_file = $aws_conf_dir->child('saml.ini');
+my $aws_creds_file = $aws_conf_dir->child('credentials');
+
+my $conf = Config::INI::Reader->read_file($saml_conf_file);
+my $domain = $conf->{_}->{domain} // die "No default domain is set in $saml_conf_file";
+my $region = $conf->{_}->{region} // die "No default region is set in $saml_conf_file";
+
+my $idpentryurl = URI->new($conf->{_}->{adfs_uri})
+  or die "Unable to get ADFS uri from $saml_conf_file";
+
+my $ua = LWP::UserAgent->new(
+    keep_alive => 1,
+    agent      => 'Mozilla/5.0',  # needed for ADFS
+    cookie_jar => { file => $aws_conf_dir->child('cookies') }, # needed for ADFS
+    ssl_opts   => { verify_hostname => 1 },
+);
+
+# First try with Negotiate/GSS
+my $res = $ua->get($idpentryurl);
+die $res->status_line unless $res->is_success;
+
+my $html = XML::XPath->new($res->decoded_content);
+# should always be the first element
+my $saml_encoded = $html->find('/html/body/form/input[@name="SAMLResponse"]')->shift->getAttribute('value');
+my $saml = decode_base64($saml_encoded);
+
+# Parse the returned assertion and extract the authorized roles
+my %aws_roles;
+my $xp    = XML::XPath->new($saml);
+my $nodes = $xp->findnodes(
+    '//samlp:Response/Assertion/AttributeStatement/Attribute[@Name="https://aws.amazon.com/SAML/Attributes/Role"]/AttributeValue'
+);
+foreach my $node ($nodes->get_nodelist) {
+    my ($principle, $role)       = split ',', $node->string_value;
+    my (undef,      $short_role) = split '/', $role;
+    if ($aws_roles{$short_role}) {
+        say "There are two roles with the same name - $short_role";
+        say $aws_roles{$short_role}->{role};
+        say $role;
+        die "Bailing out!";
+    }
+    $aws_roles{$short_role} = {principle => $principle, role => $role};
+}
+
+my $num_roles = scalar keys %aws_roles;
+my $short_role;
+
+if ($num_roles == 0) {
+    die "Could not find any roles\n";
+} elsif ($num_roles > 1) {
+    my @accounts;
+    $short_role = prompt 'Choose role...',
+      -menu => [sort (keys %aws_roles)],
+      '>';
+} else {
+    my @roles = keys %aws_roles;
+    $short_role = shift @roles;
+}
+
+printf "Attempting to assume principle [%s] - role [%s]\n",
+  $aws_roles{$short_role}->{principle}, $aws_roles{$short_role}->{role};
+
+my $creds = Paws::Credential::AssumeRoleWithSAML->new(
+    PrincipalArn  => $aws_roles{$short_role}->{principle},
+    RoleArn       => $aws_roles{$short_role}->{role},
+    SAMLAssertion => $saml_encoded,
+    sts_region    => $region,
+);
+
+my $config = {};
+if ($aws_creds_file->is_file) {
+    $config = Config::INI::Reader->read_file($aws_creds_file);
+}
+
+my $profile = lc $short_role;
+try {
+    $config->{$profile} = {
+        region                => $region,
+        aws_access_key_id     => $creds->access_key,
+        aws_secret_access_key => $creds->secret_key,
+        aws_session_token     => $creds->session_token,
+    };
+} catch(Paws::Exception $e) {
+    die sprintf "FATAL: %s - %s\n", $e->code, $e->message;
+} catch($e) {
+    die "FATAL: failed to assume role: $e\n";
+}
+
+say "Success!";
+
+Config::INI::Writer->write_file($config, $aws_creds_file);
+
+my $rows = [
+    [qw/Creds Expiration Region Profile/],
+    [$aws_creds_file, $creds->expiration, $region, $profile]];
+
+say generate_table(rows => $rows, header_row => 1);
+
+say 'To use this credential call the Paws CLI with $ENV{AWS_DEFAULT_PROFILE} set';
+say "(e.g. AWS_DEFAULT_PROFILE=$profile paws EC2 --region $region DescribeInstances)";
+
+=head1 DESCRIPTION
+
+This example will create session credentials using L<Paws::Credential::AssumeRoleWithSAML>.
+It assumes you are using Microsoft ADFS and that you have a valid Kerberos ticket.
+
+=head1 SEE ALSO
+Converted from a python script:
+https://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS

--- a/lib/Paws/Credential/AssumeRoleWithSAML.pm
+++ b/lib/Paws/Credential/AssumeRoleWithSAML.pm
@@ -1,0 +1,73 @@
+package Paws::Credential::AssumeRoleWithSAML {
+  use Moose;
+  use DateTime;
+  use DateTime::Format::ISO8601;
+  use Paws::Credential::None;
+
+  with 'Paws::Credential';
+
+  has expiration => (
+    is => 'rw',
+    isa => 'DateTime',
+    lazy => 1,
+    default => sub {
+      DateTime->from_epoch(epoch => 0); # need a better way to do this
+    }
+  );
+
+  has actual_creds => (is => 'rw');
+
+  sub access_key {
+    my $self = shift;
+    $self->_refresh;
+    $self->actual_creds->AccessKeyId;
+  }
+
+  sub secret_key {
+    my $self = shift;
+    $self->_refresh;
+    $self->actual_creds->SecretAccessKey;
+  }
+
+  sub session_token {
+    my $self = shift;
+    $self->_refresh;
+    $self->actual_creds->SessionToken;
+  }
+
+  has sts_region => (is => 'ro', isa => 'Str|Undef', default => sub { undef });
+
+  has sts => (is => 'ro', isa => 'Paws::STS', lazy => 1, default => sub {
+    my $self = shift;
+    Paws->service('STS', region => $self->sts_region, credentials => Paws::Credential::None->new);
+  });
+
+  has DurationSeconds => (is => 'rw', isa => 'Maybe[Int]');
+  has Policy => (is => 'rw', isa => 'Maybe[Str]');
+
+  has RoleArn => (is => 'rw', isa => 'Str', required => 1);
+  has PrincipalArn => (is => 'rw', isa => 'Str', required => 1);
+  has SAMLAssertion => (is => 'rw', isa => 'Str', required => 1);
+
+  sub _refresh {
+    my $self = shift;
+
+    return if (($self->expiration - DateTime->now())->is_positive);
+
+    my $result = $self->sts->AssumeRoleWithSAML(
+      RoleArn => $self->RoleArn,
+      PrincipalArn => $self->PrincipalArn,
+      SAMLAssertion => $self->SAMLAssertion,
+      (defined $self->DurationSeconds) ? (DurationSeconds => $self->DurationSeconds) : (),
+      (defined $self->Policy) ? (Policy => $self->Policy) : (),
+    );
+
+    my $creds = $self->actual_creds($result->Credentials);
+
+    $self->expiration(DateTime::Format::ISO8601->parse_datetime($result->Credentials->Expiration));
+  }
+
+  no Moose;
+}
+
+1;

--- a/lib/Paws/Credential/None.pm
+++ b/lib/Paws/Credential/None.pm
@@ -1,0 +1,14 @@
+package Paws::Credential::None {
+  use Moose;
+  with 'Paws::Credential';
+
+  sub access_key { q{} }
+
+  sub secret_key { q{} }
+
+  sub session_token { q{} }
+
+  no Moose;
+}
+
+1;


### PR DESCRIPTION
Hi,

I've been trying to STS federated login to work, as in http://blogs.aws.amazon.com/security/post/Tx1LDN0UBGJJ26Q/How-to-Implement-Federated-API-and-CLI-Access-Using-SAML-2-0-and-AD-FS

I saw that Boto handled this by adding `NO_CREDENTIALS_PROVIDED = object()` to boto/provider.py and used that for the creds in `sts/connection.py`, so I've taken a similar approach. I added a stub `Paws::Credential::None` and it is automatically used when calling `Paws->creds_service` rather than `service`. 

I put that straight in auto-lib/Paws instead of the template because I'm still playing around, and I'm not sure what the best way of handling this is. There's currently a lot of duplication in the `Paws::Credential` space.  Did you have any plans for the STS pieces?

Thanks!