### PR TITLE
Make compatible with Perl 5.10

### DIFF
--- a/lib/Paws/Credential/AssumeRoleWithSAML.pm
+++ b/lib/Paws/Credential/AssumeRoleWithSAML.pm
@@ -1,4 +1,4 @@
-package Paws::Credential::AssumeRoleWithSAML {
+package Paws::Credential::AssumeRoleWithSAML;
   use Moose;
   use DateTime;
   use DateTime::Format::ISO8601;
@@ -68,6 +68,5 @@ package Paws::Credential::AssumeRoleWithSAML {
   }
 
   no Moose;
-}
 
 1;

--- a/lib/Paws/Credential/None.pm
+++ b/lib/Paws/Credential/None.pm
@@ -1,4 +1,4 @@
-package Paws::Credential::None {
+package Paws::Credential::None;
   use Moose;
   with 'Paws::Credential';
 
@@ -9,6 +9,5 @@ package Paws::Credential::None {
   sub session_token { q{} }
 
   no Moose;
-}
 
 1;

--- a/t/10_generate_test_cases.pl
+++ b/t/10_generate_test_cases.pl
@@ -66,7 +66,7 @@ sub generate_test_case {
 
   my @tests;
 
-  foreach my $path (sort keys $result) {
+  foreach my $path (sort keys %$result) {
     push @tests, {
        path => $path,
        expected => $result->{ $path },


### PR DESCRIPTION
Removing a couple of package BLOCK and one keys REF makes the tests pass
on Perl 5.10.