### PR TITLE
Set request ID to empty string when it doesn't exist on response

### DIFF
--- a/lib/Paws/Net/XMLResponse.pm
+++ b/lib/Paws/Net/XMLResponse.pm
@@ -52,12 +52,12 @@ package Paws::Net::XMLResponse;
     } elsif (exists $headers->{ 'x-amzn-requestid' }) {
       $request_id = $headers->{ 'x-amzn-requestid' };
     } else {
-      die "Cannot find RequestId in error message"
+      $request_id = '';
     }
 
     Paws::Exception->new(
-      message => $error->{Message}, 
-      code => $code, 
+      message => $error->{Message} // $content,
+      code => $code,
       request_id => $request_id,
       http_status => $http_status,
     );

--- a/t/10_responses/sqs-service-unavailable.response
+++ b/t/10_responses/sqs-service-unavailable.response
@@ -1,0 +1,4 @@
+---
+content: "<ServiceUnavailable />"
+headers: []
+status: 503

--- a/t/10_responses/sqs-service-unavailable.response.test.yml
+++ b/t/10_responses/sqs-service-unavailable.response.test.yml
@@ -1,0 +1,15 @@
+---
+call: SendMessage
+service: SQS
+tests:
+  - expected: 503
+    op: ==
+    path: http_status
+  - expected: 503
+    op: ==
+    path: code
+  - expected: "<ServiceUnavailable />"
+    op: eq
+    path: message
+
+


### PR DESCRIPTION
I've seen scenarios where AWS (specifically SQS) will return the following response:

```
HTTP/1.1 503 Service Unavailable
Server: Server
Connection: close
Content-Length 30
Content-Type: text/xml
ETag: "56c51349-1e"
Date: Fri, 19 Aug 2016 16:39:56 GMT

<ServiceUnavailableException/>
```

This causes an unhanded exception in XMLResponse which doesn't make sense to me. There are other places in Paws where an empty request ID is passed to the exception object so I thought we could reuse it.

This will allow retry roles to pick up on the error and retry vs Paws users having to implement their own retry.