### PR TITLE
Fix messed up call/result doc generation

### DIFF
--- a/auto-lib/Paws/S3/AbortMultipartUpload.pm
+++ b/auto-lib/Paws/S3/AbortMultipartUpload.pm
@@ -20,7 +20,21 @@ package Paws::S3::AbortMultipartUpload;
 
 =head1 NAME
 
-Paws::S3::AbortMultipartUploadOutput
+Paws::S3::AbortMultipartUpload - Arguments for method AbortMultipartUpload on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method AbortMultipartUpload on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method AbortMultipartUpload.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to AbortMultipartUpload.
+
+As an example:
+
+  $service_obj->AbortMultipartUpload(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -49,6 +63,16 @@ Valid values are: C<"requester">
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method AbortMultipartUpload in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/AbortMultipartUploadOutput.pm
+++ b/auto-lib/Paws/S3/AbortMultipartUploadOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::AbortMultipartUploadOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::AbortMultipartUploadOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CompleteMultipartUpload.pm
+++ b/auto-lib/Paws/S3/CompleteMultipartUpload.pm
@@ -21,7 +21,21 @@ package Paws::S3::CompleteMultipartUpload;
 
 =head1 NAME
 
-Paws::S3::CompleteMultipartUploadOutput
+Paws::S3::CompleteMultipartUpload - Arguments for method CompleteMultipartUpload on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method CompleteMultipartUpload on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method CompleteMultipartUpload.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to CompleteMultipartUpload.
+
+As an example:
+
+  $service_obj->CompleteMultipartUpload(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -56,6 +70,16 @@ Valid values are: C<"requester">
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method CompleteMultipartUpload in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CompleteMultipartUploadOutput.pm
+++ b/auto-lib/Paws/S3/CompleteMultipartUploadOutput.pm
@@ -17,21 +17,7 @@ package Paws::S3::CompleteMultipartUploadOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::CompleteMultipartUploadOutput
 
 =head1 ATTRIBUTES
 
@@ -94,16 +80,6 @@ Version of the object.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CopyObject.pm
+++ b/auto-lib/Paws/S3/CopyObject.pm
@@ -47,7 +47,21 @@ package Paws::S3::CopyObject;
 
 =head1 NAME
 
-Paws::S3::CopyObjectOutput
+Paws::S3::CopyObject - Arguments for method CopyObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method CopyObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method CopyObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to CopyObject.
+
+As an example:
+
+  $service_obj->CopyObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -263,6 +277,16 @@ Amazon S3 stores the value of this header in the object metadata.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method CopyObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CopyObjectOutput.pm
+++ b/auto-lib/Paws/S3/CopyObjectOutput.pm
@@ -17,21 +17,7 @@ package Paws::S3::CopyObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::CopyObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -97,16 +83,6 @@ Version ID of the newly created copy.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CreateBucket.pm
+++ b/auto-lib/Paws/S3/CreateBucket.pm
@@ -24,7 +24,21 @@ package Paws::S3::CreateBucket;
 
 =head1 NAME
 
-Paws::S3::CreateBucketOutput
+Paws::S3::CreateBucket - Arguments for method CreateBucket on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method CreateBucket on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method CreateBucket.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to CreateBucket.
+
+As an example:
+
+  $service_obj->CreateBucket(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -79,6 +93,16 @@ Allows grantee to write the ACL for the applicable bucket.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method CreateBucket in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CreateBucketOutput.pm
+++ b/auto-lib/Paws/S3/CreateBucketOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::CreateBucketOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::CreateBucketOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CreateMultipartUpload.pm
+++ b/auto-lib/Paws/S3/CreateMultipartUpload.pm
@@ -38,7 +38,21 @@ package Paws::S3::CreateMultipartUpload;
 
 =head1 NAME
 
-Paws::S3::CreateMultipartUploadOutput
+Paws::S3::CreateMultipartUpload - Arguments for method CreateMultipartUpload on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method CreateMultipartUpload on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method CreateMultipartUpload.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to CreateMultipartUpload.
+
+As an example:
+
+  $service_obj->CreateMultipartUpload(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -192,6 +206,16 @@ Amazon S3 stores the value of this header in the object metadata.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method CreateMultipartUpload in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/CreateMultipartUploadOutput.pm
+++ b/auto-lib/Paws/S3/CreateMultipartUploadOutput.pm
@@ -18,21 +18,7 @@ package Paws::S3::CreateMultipartUploadOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::CreateMultipartUploadOutput
 
 =head1 ATTRIBUTES
 
@@ -105,16 +91,6 @@ ID for the initiated multipart upload.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucket.pm
+++ b/auto-lib/Paws/S3/DeleteBucket.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucket;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucket - Arguments for method DeleteBucket on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucket on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucket.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucket.
+
+As an example:
+
+  $service_obj->DeleteBucket(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucket in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketCors.pm
+++ b/auto-lib/Paws/S3/DeleteBucketCors.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketCors;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketCors - Arguments for method DeleteBucketCors on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketCors on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketCors.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketCors.
+
+As an example:
+
+  $service_obj->DeleteBucketCors(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketCors in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketLifecycle.pm
+++ b/auto-lib/Paws/S3/DeleteBucketLifecycle.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketLifecycle;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketLifecycle - Arguments for method DeleteBucketLifecycle on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketLifecycle on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketLifecycle.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketLifecycle.
+
+As an example:
+
+  $service_obj->DeleteBucketLifecycle(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketLifecycle in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketPolicy.pm
+++ b/auto-lib/Paws/S3/DeleteBucketPolicy.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketPolicy;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketPolicy - Arguments for method DeleteBucketPolicy on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketPolicy on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketPolicy.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketPolicy.
+
+As an example:
+
+  $service_obj->DeleteBucketPolicy(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketPolicy in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketReplication.pm
+++ b/auto-lib/Paws/S3/DeleteBucketReplication.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketReplication;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketReplication - Arguments for method DeleteBucketReplication on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketReplication on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketReplication.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketReplication.
+
+As an example:
+
+  $service_obj->DeleteBucketReplication(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketReplication in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketTagging.pm
+++ b/auto-lib/Paws/S3/DeleteBucketTagging.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketTagging;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketTagging - Arguments for method DeleteBucketTagging on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketTagging on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketTagging.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketTagging.
+
+As an example:
+
+  $service_obj->DeleteBucketTagging(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketTagging in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteBucketWebsite.pm
+++ b/auto-lib/Paws/S3/DeleteBucketWebsite.pm
@@ -17,7 +17,21 @@ package Paws::S3::DeleteBucketWebsite;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::DeleteBucketWebsite - Arguments for method DeleteBucketWebsite on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteBucketWebsite on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteBucketWebsite.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteBucketWebsite.
+
+As an example:
+
+  $service_obj->DeleteBucketWebsite(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteBucketWebsite in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteObject.pm
+++ b/auto-lib/Paws/S3/DeleteObject.pm
@@ -21,7 +21,21 @@ package Paws::S3::DeleteObject;
 
 =head1 NAME
 
-Paws::S3::DeleteObjectOutput
+Paws::S3::DeleteObject - Arguments for method DeleteObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteObject.
+
+As an example:
+
+  $service_obj->DeleteObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -57,6 +71,16 @@ VersionId used to reference a specific version of the object.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteObjectOutput.pm
+++ b/auto-lib/Paws/S3/DeleteObjectOutput.pm
@@ -11,21 +11,7 @@ package Paws::S3::DeleteObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::DeleteObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -50,16 +36,6 @@ DELETE operation.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteObjects.pm
+++ b/auto-lib/Paws/S3/DeleteObjects.pm
@@ -20,7 +20,21 @@ package Paws::S3::DeleteObjects;
 
 =head1 NAME
 
-Paws::S3::DeleteObjectsOutput
+Paws::S3::DeleteObjects - Arguments for method DeleteObjects on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method DeleteObjects on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method DeleteObjects.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to DeleteObjects.
+
+As an example:
+
+  $service_obj->DeleteObjects(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -50,6 +64,16 @@ space, and the value that is displayed on your authentication device.
 
 Valid values are: C<"requester">
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method DeleteObjects in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/DeleteObjectsOutput.pm
+++ b/auto-lib/Paws/S3/DeleteObjectsOutput.pm
@@ -11,21 +11,7 @@ package Paws::S3::DeleteObjectsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::DeleteObjectsOutput
 
 =head1 ATTRIBUTES
 
@@ -48,16 +34,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketAccelerateConfiguration.pm
+++ b/auto-lib/Paws/S3/GetBucketAccelerateConfiguration.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketAccelerateConfiguration;
 
 =head1 NAME
 
-Paws::S3::GetBucketAccelerateConfigurationOutput
+Paws::S3::GetBucketAccelerateConfiguration - Arguments for method GetBucketAccelerateConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketAccelerateConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketAccelerateConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketAccelerateConfiguration.
+
+As an example:
+
+  $service_obj->GetBucketAccelerateConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Name of the bucket for which the accelerate configuration is retrieved.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketAccelerateConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketAccelerateConfigurationOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketAccelerateConfigurationOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketAccelerateConfigurationOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketAccelerateConfigurationOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ The accelerate configuration of the bucket.
 
 Valid values are: C<"Enabled">, C<"Suspended">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketAcl.pm
+++ b/auto-lib/Paws/S3/GetBucketAcl.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketAcl;
 
 =head1 NAME
 
-Paws::S3::GetBucketAclOutput
+Paws::S3::GetBucketAcl - Arguments for method GetBucketAcl on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketAcl on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketAcl.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketAcl.
+
+As an example:
+
+  $service_obj->GetBucketAcl(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketAclOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketAcl in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketAclOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketAclOutput.pm
@@ -10,21 +10,7 @@ package Paws::S3::GetBucketAclOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketAclOutput
 
 =head1 ATTRIBUTES
 
@@ -41,16 +27,6 @@ A list of grants.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketCors.pm
+++ b/auto-lib/Paws/S3/GetBucketCors.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketCors;
 
 =head1 NAME
 
-Paws::S3::GetBucketCorsOutput
+Paws::S3::GetBucketCors - Arguments for method GetBucketCors on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketCors on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketCors.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketCors.
+
+As an example:
+
+  $service_obj->GetBucketCors(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketCorsOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketCors in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketCorsOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketCorsOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketCorsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketCorsOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLifecycle.pm
+++ b/auto-lib/Paws/S3/GetBucketLifecycle.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketLifecycle;
 
 =head1 NAME
 
-Paws::S3::GetBucketLifecycleOutput
+Paws::S3::GetBucketLifecycle - Arguments for method GetBucketLifecycle on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketLifecycle on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketLifecycle.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketLifecycle.
+
+As an example:
+
+  $service_obj->GetBucketLifecycle(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketLifecycleOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketLifecycle in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLifecycleConfiguration.pm
+++ b/auto-lib/Paws/S3/GetBucketLifecycleConfiguration.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketLifecycleConfiguration;
 
 =head1 NAME
 
-Paws::S3::GetBucketLifecycleConfigurationOutput
+Paws::S3::GetBucketLifecycleConfiguration - Arguments for method GetBucketLifecycleConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketLifecycleConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketLifecycleConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketLifecycleConfiguration.
+
+As an example:
+
+  $service_obj->GetBucketLifecycleConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketLifecycleConfigurationOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketLifecycleConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLifecycleConfigurationOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketLifecycleConfigurationOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketLifecycleConfigurationOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketLifecycleConfigurationOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLifecycleOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketLifecycleOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketLifecycleOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketLifecycleOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLocation.pm
+++ b/auto-lib/Paws/S3/GetBucketLocation.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketLocation;
 
 =head1 NAME
 
-Paws::S3::GetBucketLocationOutput
+Paws::S3::GetBucketLocation - Arguments for method GetBucketLocation on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketLocation on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketLocation.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketLocation.
+
+As an example:
+
+  $service_obj->GetBucketLocation(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketLocationOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketLocation in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLocationOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketLocationOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketLocationOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketLocationOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"EU">, C<"eu-west-1">, C<"us-west-1">, C<"us-west-2">, C<"ap-south-1">, C<"ap-southeast-1">, C<"ap-southeast-2">, C<"ap-northeast-1">, C<"sa-east-1">, C<"cn-north-1">, C<"eu-central-1">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLogging.pm
+++ b/auto-lib/Paws/S3/GetBucketLogging.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketLogging;
 
 =head1 NAME
 
-Paws::S3::GetBucketLoggingOutput
+Paws::S3::GetBucketLogging - Arguments for method GetBucketLogging on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketLogging on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketLogging.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketLogging.
+
+As an example:
+
+  $service_obj->GetBucketLogging(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketLoggingOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketLogging in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketLoggingOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketLoggingOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketLoggingOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketLoggingOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketNotification.pm
+++ b/auto-lib/Paws/S3/GetBucketNotification.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketNotification;
 
 =head1 NAME
 
-Paws::S3::NotificationConfigurationDeprecated
+Paws::S3::GetBucketNotification - Arguments for method GetBucketNotification on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketNotification on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketNotification.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketNotification.
+
+As an example:
+
+  $service_obj->GetBucketNotification(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Name of the bucket to get the notification configuration for.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketNotification in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketNotificationConfiguration.pm
+++ b/auto-lib/Paws/S3/GetBucketNotificationConfiguration.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketNotificationConfiguration;
 
 =head1 NAME
 
-Paws::S3::NotificationConfiguration
+Paws::S3::GetBucketNotificationConfiguration - Arguments for method GetBucketNotificationConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketNotificationConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketNotificationConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketNotificationConfiguration.
+
+As an example:
+
+  $service_obj->GetBucketNotificationConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Name of the bucket to get the notification configuration for.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketNotificationConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketPolicy.pm
+++ b/auto-lib/Paws/S3/GetBucketPolicy.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketPolicy;
 
 =head1 NAME
 
-Paws::S3::GetBucketPolicyOutput
+Paws::S3::GetBucketPolicy - Arguments for method GetBucketPolicy on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketPolicy on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketPolicy.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketPolicy.
+
+As an example:
+
+  $service_obj->GetBucketPolicy(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketPolicyOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketPolicy in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketPolicyOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketPolicyOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketPolicyOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketPolicyOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ The bucket policy as a JSON document.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketReplication.pm
+++ b/auto-lib/Paws/S3/GetBucketReplication.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketReplication;
 
 =head1 NAME
 
-Paws::S3::GetBucketReplicationOutput
+Paws::S3::GetBucketReplication - Arguments for method GetBucketReplication on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketReplication on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketReplication.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketReplication.
+
+As an example:
+
+  $service_obj->GetBucketReplication(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketReplicationOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketReplication in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketReplicationOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketReplicationOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketReplicationOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketReplicationOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketRequestPayment.pm
+++ b/auto-lib/Paws/S3/GetBucketRequestPayment.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketRequestPayment;
 
 =head1 NAME
 
-Paws::S3::GetBucketRequestPaymentOutput
+Paws::S3::GetBucketRequestPayment - Arguments for method GetBucketRequestPayment on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketRequestPayment on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketRequestPayment.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketRequestPayment.
+
+As an example:
+
+  $service_obj->GetBucketRequestPayment(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketRequestPaymentOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketRequestPayment in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketRequestPaymentOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketRequestPaymentOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketRequestPaymentOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketRequestPaymentOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Specifies who pays for the download and request fees.
 
 Valid values are: C<"Requester">, C<"BucketOwner">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketTagging.pm
+++ b/auto-lib/Paws/S3/GetBucketTagging.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketTagging;
 
 =head1 NAME
 
-Paws::S3::GetBucketTaggingOutput
+Paws::S3::GetBucketTagging - Arguments for method GetBucketTagging on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketTagging on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketTagging.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketTagging.
+
+As an example:
+
+  $service_obj->GetBucketTagging(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketTaggingOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketTagging in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketTaggingOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketTaggingOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::GetBucketTaggingOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketTaggingOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketVersioning.pm
+++ b/auto-lib/Paws/S3/GetBucketVersioning.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketVersioning;
 
 =head1 NAME
 
-Paws::S3::GetBucketVersioningOutput
+Paws::S3::GetBucketVersioning - Arguments for method GetBucketVersioning on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketVersioning on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketVersioning.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketVersioning.
+
+As an example:
+
+  $service_obj->GetBucketVersioning(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketVersioningOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketVersioning in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketVersioningOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketVersioningOutput.pm
@@ -10,21 +10,7 @@ package Paws::S3::GetBucketVersioningOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketVersioningOutput
 
 =head1 ATTRIBUTES
 
@@ -44,16 +30,6 @@ The versioning state of the bucket.
 
 Valid values are: C<"Enabled">, C<"Suspended">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketWebsite.pm
+++ b/auto-lib/Paws/S3/GetBucketWebsite.pm
@@ -17,7 +17,21 @@ package Paws::S3::GetBucketWebsite;
 
 =head1 NAME
 
-Paws::S3::GetBucketWebsiteOutput
+Paws::S3::GetBucketWebsite - Arguments for method GetBucketWebsite on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetBucketWebsite on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetBucketWebsite.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetBucketWebsite.
+
+As an example:
+
+  $service_obj->GetBucketWebsite(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::GetBucketWebsiteOutput
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetBucketWebsite in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetBucketWebsiteOutput.pm
+++ b/auto-lib/Paws/S3/GetBucketWebsiteOutput.pm
@@ -12,21 +12,7 @@ package Paws::S3::GetBucketWebsiteOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetBucketWebsiteOutput
 
 =head1 ATTRIBUTES
 
@@ -55,16 +41,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObject.pm
+++ b/auto-lib/Paws/S3/GetObject.pm
@@ -34,7 +34,21 @@ package Paws::S3::GetObject;
 
 =head1 NAME
 
-Paws::S3::GetObjectOutput
+Paws::S3::GetObject - Arguments for method GetObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetObject.
+
+As an example:
+
+  $service_obj->GetObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -160,6 +174,16 @@ VersionId used to reference a specific version of the object.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObjectAcl.pm
+++ b/auto-lib/Paws/S3/GetObjectAcl.pm
@@ -20,7 +20,21 @@ package Paws::S3::GetObjectAcl;
 
 =head1 NAME
 
-Paws::S3::GetObjectAclOutput
+Paws::S3::GetObjectAcl - Arguments for method GetObjectAcl on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetObjectAcl on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetObjectAcl.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetObjectAcl.
+
+As an example:
+
+  $service_obj->GetObjectAcl(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -49,6 +63,16 @@ VersionId used to reference a specific version of the object.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetObjectAcl in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObjectAclOutput.pm
+++ b/auto-lib/Paws/S3/GetObjectAclOutput.pm
@@ -11,21 +11,7 @@ package Paws::S3::GetObjectAclOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetObjectAclOutput
 
 =head1 ATTRIBUTES
 
@@ -48,16 +34,6 @@ A list of grants.
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObjectOutput.pm
+++ b/auto-lib/Paws/S3/GetObjectOutput.pm
@@ -35,21 +35,7 @@ package Paws::S3::GetObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -231,16 +217,6 @@ Amazon S3 stores the value of this header in the object metadata.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObjectTorrent.pm
+++ b/auto-lib/Paws/S3/GetObjectTorrent.pm
@@ -19,7 +19,21 @@ package Paws::S3::GetObjectTorrent;
 
 =head1 NAME
 
-Paws::S3::GetObjectTorrentOutput
+Paws::S3::GetObjectTorrent - Arguments for method GetObjectTorrent on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method GetObjectTorrent on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method GetObjectTorrent.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to GetObjectTorrent.
+
+As an example:
+
+  $service_obj->GetObjectTorrent(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::GetObjectTorrentOutput
 
 Valid values are: C<"requester">
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method GetObjectTorrent in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/GetObjectTorrentOutput.pm
+++ b/auto-lib/Paws/S3/GetObjectTorrentOutput.pm
@@ -11,21 +11,7 @@ package Paws::S3::GetObjectTorrentOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::GetObjectTorrentOutput
 
 =head1 ATTRIBUTES
 
@@ -42,16 +28,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/HeadBucket.pm
+++ b/auto-lib/Paws/S3/HeadBucket.pm
@@ -17,7 +17,21 @@ package Paws::S3::HeadBucket;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::HeadBucket - Arguments for method HeadBucket on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method HeadBucket on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method HeadBucket.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to HeadBucket.
+
+As an example:
+
+  $service_obj->HeadBucket(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -28,6 +42,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method HeadBucket in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/HeadObject.pm
+++ b/auto-lib/Paws/S3/HeadObject.pm
@@ -28,7 +28,21 @@ package Paws::S3::HeadObject;
 
 =head1 NAME
 
-Paws::S3::HeadObjectOutput
+Paws::S3::HeadObject - Arguments for method HeadObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method HeadObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method HeadObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to HeadObject.
+
+As an example:
+
+  $service_obj->HeadObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -118,6 +132,16 @@ VersionId used to reference a specific version of the object.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method HeadObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/HeadObjectOutput.pm
+++ b/auto-lib/Paws/S3/HeadObjectOutput.pm
@@ -32,21 +32,7 @@ package Paws::S3::HeadObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::HeadObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -216,16 +202,6 @@ Amazon S3 stores the value of this header in the object metadata.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListBuckets.pm
+++ b/auto-lib/Paws/S3/ListBuckets.pm
@@ -16,11 +16,35 @@ package Paws::S3::ListBuckets;
 
 =head1 NAME
 
-Paws::S3::ListBucketsOutput
+Paws::S3::ListBuckets - Arguments for method ListBuckets on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListBuckets on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListBuckets.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListBuckets.
+
+As an example:
+
+  $service_obj->ListBuckets(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListBuckets in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListBucketsOutput.pm
+++ b/auto-lib/Paws/S3/ListBucketsOutput.pm
@@ -10,21 +10,7 @@ package Paws::S3::ListBucketsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListBucketsOutput
 
 =head1 ATTRIBUTES
 
@@ -41,16 +27,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListMultipartUploads.pm
+++ b/auto-lib/Paws/S3/ListMultipartUploads.pm
@@ -23,7 +23,21 @@ package Paws::S3::ListMultipartUploads;
 
 =head1 NAME
 
-Paws::S3::ListMultipartUploadsOutput
+Paws::S3::ListMultipartUploads - Arguments for method ListMultipartUploads on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListMultipartUploads on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListMultipartUploads.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListMultipartUploads.
+
+As an example:
+
+  $service_obj->ListMultipartUploads(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -76,6 +90,16 @@ upload-id-marker parameter is ignored.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListMultipartUploads in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListMultipartUploadsOutput.pm
+++ b/auto-lib/Paws/S3/ListMultipartUploadsOutput.pm
@@ -20,21 +20,7 @@ package Paws::S3::ListMultipartUploadsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListMultipartUploadsOutput
 
 =head1 ATTRIBUTES
 
@@ -120,16 +106,6 @@ Upload ID after which listing began.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjectVersions.pm
+++ b/auto-lib/Paws/S3/ListObjectVersions.pm
@@ -23,7 +23,21 @@ package Paws::S3::ListObjectVersions;
 
 =head1 NAME
 
-Paws::S3::ListObjectVersionsOutput
+Paws::S3::ListObjectVersions - Arguments for method ListObjectVersions on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListObjectVersions on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListObjectVersions.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListObjectVersions.
+
+As an example:
+
+  $service_obj->ListObjectVersions(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -71,6 +85,16 @@ Specifies the object version you want to start listing from.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListObjectVersions in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjectVersionsOutput.pm
+++ b/auto-lib/Paws/S3/ListObjectVersionsOutput.pm
@@ -21,21 +21,7 @@ package Paws::S3::ListObjectVersionsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListObjectVersionsOutput
 
 =head1 ATTRIBUTES
 
@@ -124,16 +110,6 @@ request.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjects.pm
+++ b/auto-lib/Paws/S3/ListObjects.pm
@@ -22,7 +22,21 @@ package Paws::S3::ListObjects;
 
 =head1 NAME
 
-Paws::S3::ListObjectsOutput
+Paws::S3::ListObjects - Arguments for method ListObjects on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListObjects on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListObjects.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListObjects.
+
+As an example:
+
+  $service_obj->ListObjects(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -64,6 +78,16 @@ Limits the response to keys that begin with the specified prefix.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListObjects in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjectsOutput.pm
+++ b/auto-lib/Paws/S3/ListObjectsOutput.pm
@@ -18,21 +18,7 @@ package Paws::S3::ListObjectsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListObjectsOutput
 
 =head1 ATTRIBUTES
 
@@ -105,16 +91,6 @@ the next set of object keys.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjectsV2.pm
+++ b/auto-lib/Paws/S3/ListObjectsV2.pm
@@ -24,7 +24,21 @@ package Paws::S3::ListObjectsV2;
 
 =head1 NAME
 
-Paws::S3::ListObjectsV2Output
+Paws::S3::ListObjectsV2 - Arguments for method ListObjectsV2 on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListObjectsV2 on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListObjectsV2.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListObjectsV2.
+
+As an example:
+
+  $service_obj->ListObjectsV2(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -84,6 +98,16 @@ the bucket
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListObjectsV2 in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListObjectsV2Output.pm
+++ b/auto-lib/Paws/S3/ListObjectsV2Output.pm
@@ -20,21 +20,7 @@ package Paws::S3::ListObjectsV2Output;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListObjectsV2Output
 
 =head1 ATTRIBUTES
 
@@ -123,16 +109,6 @@ the bucket
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListParts.pm
+++ b/auto-lib/Paws/S3/ListParts.pm
@@ -22,7 +22,21 @@ package Paws::S3::ListParts;
 
 =head1 NAME
 
-Paws::S3::ListPartsOutput
+Paws::S3::ListParts - Arguments for method ListParts on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method ListParts on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method ListParts.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to ListParts.
+
+As an example:
+
+  $service_obj->ListParts(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -65,6 +79,16 @@ listed.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method ListParts in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/ListPartsOutput.pm
+++ b/auto-lib/Paws/S3/ListPartsOutput.pm
@@ -22,21 +22,7 @@ package Paws::S3::ListPartsOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::ListPartsOutput
 
 =head1 ATTRIBUTES
 
@@ -130,16 +116,6 @@ listed.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/NotificationConfiguration.pm
+++ b/auto-lib/Paws/S3/NotificationConfiguration.pm
@@ -11,21 +11,7 @@ package Paws::S3::NotificationConfiguration;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::NotificationConfiguration
 
 =head1 ATTRIBUTES
 
@@ -48,16 +34,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/NotificationConfigurationDeprecated.pm
+++ b/auto-lib/Paws/S3/NotificationConfigurationDeprecated.pm
@@ -11,21 +11,7 @@ package Paws::S3::NotificationConfigurationDeprecated;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::NotificationConfigurationDeprecated
 
 =head1 ATTRIBUTES
 
@@ -48,16 +34,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketAccelerateConfiguration.pm
+++ b/auto-lib/Paws/S3/PutBucketAccelerateConfiguration.pm
@@ -18,7 +18,21 @@ package Paws::S3::PutBucketAccelerateConfiguration;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketAccelerateConfiguration - Arguments for method PutBucketAccelerateConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketAccelerateConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketAccelerateConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketAccelerateConfiguration.
+
+As an example:
+
+  $service_obj->PutBucketAccelerateConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -35,6 +49,16 @@ Name of the bucket for which the accelerate configuration is set.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketAccelerateConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketAcl.pm
+++ b/auto-lib/Paws/S3/PutBucketAcl.pm
@@ -25,7 +25,21 @@ package Paws::S3::PutBucketAcl;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketAcl - Arguments for method PutBucketAcl on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketAcl on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketAcl.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketAcl.
+
+As an example:
+
+  $service_obj->PutBucketAcl(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -86,6 +100,16 @@ Allows grantee to write the ACL for the applicable bucket.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketAcl in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketCors.pm
+++ b/auto-lib/Paws/S3/PutBucketCors.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketCors;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketCors - Arguments for method PutBucketCors on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketCors on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketCors.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketCors.
+
+As an example:
+
+  $service_obj->PutBucketCors(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketCors in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketLifecycle.pm
+++ b/auto-lib/Paws/S3/PutBucketLifecycle.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketLifecycle;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketLifecycle - Arguments for method PutBucketLifecycle on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketLifecycle on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketLifecycle.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketLifecycle.
+
+As an example:
+
+  $service_obj->PutBucketLifecycle(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketLifecycle in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketLifecycleConfiguration.pm
+++ b/auto-lib/Paws/S3/PutBucketLifecycleConfiguration.pm
@@ -18,7 +18,21 @@ package Paws::S3::PutBucketLifecycleConfiguration;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketLifecycleConfiguration - Arguments for method PutBucketLifecycleConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketLifecycleConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketLifecycleConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketLifecycleConfiguration.
+
+As an example:
+
+  $service_obj->PutBucketLifecycleConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -35,6 +49,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketLifecycleConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketLogging.pm
+++ b/auto-lib/Paws/S3/PutBucketLogging.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketLogging;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketLogging - Arguments for method PutBucketLogging on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketLogging on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketLogging.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketLogging.
+
+As an example:
+
+  $service_obj->PutBucketLogging(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketLogging in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketNotification.pm
+++ b/auto-lib/Paws/S3/PutBucketNotification.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketNotification;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketNotification - Arguments for method PutBucketNotification on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketNotification on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketNotification.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketNotification.
+
+As an example:
+
+  $service_obj->PutBucketNotification(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketNotification in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketNotificationConfiguration.pm
+++ b/auto-lib/Paws/S3/PutBucketNotificationConfiguration.pm
@@ -18,7 +18,21 @@ package Paws::S3::PutBucketNotificationConfiguration;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketNotificationConfiguration - Arguments for method PutBucketNotificationConfiguration on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketNotificationConfiguration on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketNotificationConfiguration.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketNotificationConfiguration.
+
+As an example:
+
+  $service_obj->PutBucketNotificationConfiguration(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -35,6 +49,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketNotificationConfiguration in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketPolicy.pm
+++ b/auto-lib/Paws/S3/PutBucketPolicy.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketPolicy;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketPolicy - Arguments for method PutBucketPolicy on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketPolicy on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketPolicy.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketPolicy.
+
+As an example:
+
+  $service_obj->PutBucketPolicy(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ The bucket policy as a JSON document.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketPolicy in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketReplication.pm
+++ b/auto-lib/Paws/S3/PutBucketReplication.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketReplication;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketReplication - Arguments for method PutBucketReplication on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketReplication on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketReplication.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketReplication.
+
+As an example:
+
+  $service_obj->PutBucketReplication(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketReplication in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketRequestPayment.pm
+++ b/auto-lib/Paws/S3/PutBucketRequestPayment.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketRequestPayment;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketRequestPayment - Arguments for method PutBucketRequestPayment on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketRequestPayment on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketRequestPayment.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketRequestPayment.
+
+As an example:
+
+  $service_obj->PutBucketRequestPayment(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketRequestPayment in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketTagging.pm
+++ b/auto-lib/Paws/S3/PutBucketTagging.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketTagging;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketTagging - Arguments for method PutBucketTagging on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketTagging on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketTagging.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketTagging.
+
+As an example:
+
+  $service_obj->PutBucketTagging(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketTagging in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketVersioning.pm
+++ b/auto-lib/Paws/S3/PutBucketVersioning.pm
@@ -20,7 +20,21 @@ package Paws::S3::PutBucketVersioning;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketVersioning - Arguments for method PutBucketVersioning on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketVersioning on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketVersioning.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketVersioning.
+
+As an example:
+
+  $service_obj->PutBucketVersioning(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -50,6 +64,16 @@ space, and the value that is displayed on your authentication device.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketVersioning in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutBucketWebsite.pm
+++ b/auto-lib/Paws/S3/PutBucketWebsite.pm
@@ -19,7 +19,21 @@ package Paws::S3::PutBucketWebsite;
 
 =head1 NAME
 
-Paws::S3::
+Paws::S3::PutBucketWebsite - Arguments for method PutBucketWebsite on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutBucketWebsite on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutBucketWebsite.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutBucketWebsite.
+
+As an example:
+
+  $service_obj->PutBucketWebsite(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -42,6 +56,16 @@ Paws::S3::
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutBucketWebsite in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutObject.pm
+++ b/auto-lib/Paws/S3/PutObject.pm
@@ -41,7 +41,21 @@ package Paws::S3::PutObject;
 
 =head1 NAME
 
-Paws::S3::PutObjectOutput
+Paws::S3::PutObject - Arguments for method PutObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutObject.
+
+As an example:
+
+  $service_obj->PutObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -214,6 +228,16 @@ Amazon S3 stores the value of this header in the object metadata.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutObjectAcl.pm
+++ b/auto-lib/Paws/S3/PutObjectAcl.pm
@@ -28,7 +28,21 @@ package Paws::S3::PutObjectAcl;
 
 =head1 NAME
 
-Paws::S3::PutObjectAclOutput
+Paws::S3::PutObjectAcl - Arguments for method PutObjectAcl on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method PutObjectAcl on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method PutObjectAcl.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to PutObjectAcl.
+
+As an example:
+
+  $service_obj->PutObjectAcl(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -107,6 +121,16 @@ VersionId used to reference a specific version of the object.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method PutObjectAcl in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutObjectAclOutput.pm
+++ b/auto-lib/Paws/S3/PutObjectAclOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::PutObjectAclOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::PutObjectAclOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/PutObjectOutput.pm
+++ b/auto-lib/Paws/S3/PutObjectOutput.pm
@@ -16,21 +16,7 @@ package Paws::S3::PutObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::PutObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -91,16 +77,6 @@ Version of the object.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/RestoreObject.pm
+++ b/auto-lib/Paws/S3/RestoreObject.pm
@@ -21,7 +21,21 @@ package Paws::S3::RestoreObject;
 
 =head1 NAME
 
-Paws::S3::RestoreObjectOutput
+Paws::S3::RestoreObject - Arguments for method RestoreObject on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method RestoreObject on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method RestoreObject.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to RestoreObject.
+
+As an example:
+
+  $service_obj->RestoreObject(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -56,6 +70,16 @@ Valid values are: C<"requester">
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method RestoreObject in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/RestoreObjectOutput.pm
+++ b/auto-lib/Paws/S3/RestoreObjectOutput.pm
@@ -9,21 +9,7 @@ package Paws::S3::RestoreObjectOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::RestoreObjectOutput
 
 =head1 ATTRIBUTES
 
@@ -34,16 +20,6 @@ Values for attributes that are native types (Int, String, Float, etc) can passed
 
 Valid values are: C<"requester">
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/UploadPart.pm
+++ b/auto-lib/Paws/S3/UploadPart.pm
@@ -27,7 +27,21 @@ package Paws::S3::UploadPart;
 
 =head1 NAME
 
-Paws::S3::UploadPartOutput
+Paws::S3::UploadPart - Arguments for method UploadPart on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method UploadPart on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method UploadPart.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to UploadPart.
+
+As an example:
+
+  $service_obj->UploadPart(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -110,6 +124,16 @@ uploaded.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method UploadPart in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/UploadPartCopy.pm
+++ b/auto-lib/Paws/S3/UploadPartCopy.pm
@@ -33,7 +33,21 @@ package Paws::S3::UploadPartCopy;
 
 =head1 NAME
 
-Paws::S3::UploadPartCopyOutput
+Paws::S3::UploadPartCopy - Arguments for method UploadPartCopy on Paws::S3
+
+=head1 DESCRIPTION
+
+This class represents the parameters used for calling the method UploadPartCopy on the 
+Amazon Simple Storage Service service. Use the attributes of this class
+as arguments to method UploadPartCopy.
+
+You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to UploadPartCopy.
+
+As an example:
+
+  $service_obj->UploadPartCopy(Att1 => $value1, Att2 => $value2, ...);
+
+Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
 
 =head1 ATTRIBUTES
 
@@ -161,6 +175,16 @@ Upload ID identifying the multipart upload whose part is being copied.
 
 
 
+
+=head1 SEE ALSO
+
+This class forms part of L<Paws>, documenting arguments for method UploadPartCopy in L<Paws::S3>
+
+=head1 BUGS and CONTRIBUTIONS
+
+The source code is located here: https://github.com/pplu/aws-sdk-perl
+
+Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/UploadPartCopyOutput.pm
+++ b/auto-lib/Paws/S3/UploadPartCopyOutput.pm
@@ -15,21 +15,7 @@ package Paws::S3::UploadPartCopyOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::UploadPartCopyOutput
 
 =head1 ATTRIBUTES
 
@@ -83,16 +69,6 @@ master encryption key that was used for the object.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/auto-lib/Paws/S3/UploadPartOutput.pm
+++ b/auto-lib/Paws/S3/UploadPartOutput.pm
@@ -14,21 +14,7 @@ package Paws::S3::UploadPartOutput;
 
 =head1 NAME
 
-Paws::S3:: - Arguments for method  on Paws::S3
-
-=head1 DESCRIPTION
-
-This class represents the parameters used for calling the method  on the 
-Amazon Simple Storage Service service. Use the attributes of this class
-as arguments to method .
-
-You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to .
-
-As an example:
-
-  $service_obj->(Att1 => $value1, Att2 => $value2, ...);
-
-Values for attributes that are native types (Int, String, Float, etc) can passed as-is (scalar values). Values for complex Types (objects) can be passed as a HashRef. The keys and values of the hashref will be used to instance the underlying object.
+Paws::S3::UploadPartOutput
 
 =head1 ATTRIBUTES
 
@@ -75,16 +61,6 @@ master encryption key that was used for the object.
 
 
 
-
-=head1 SEE ALSO
-
-This class forms part of L<Paws>, documenting arguments for method  in L<Paws::S3>
-
-=head1 BUGS and CONTRIBUTIONS
-
-The source code is located here: https://github.com/pplu/aws-sdk-perl
-
-Please report bugs to: https://github.com/pplu/aws-sdk-perl/issues
 
 =cut
 

--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -307,7 +307,7 @@ package Paws::API::Builder {
 
 =head1 NAME
 
-[% c.api %]::[% c.shapename_for_operation_output(op_name) %]
+[% c.api %]::[% op_name %]
 
 =head1 ATTRIBUTES
 

--- a/builder-lib/Paws/API/Builder/restxml.pm
+++ b/builder-lib/Paws/API/Builder/restxml.pm
@@ -35,14 +35,15 @@ package [% c.api %]::[% op_name %];
   class_has _result_key => (isa => 'Str', is => 'ro');
   [% IF (stream_param) %]class_has _stream_param => (is => 'ro', default => '[% stream_param %]');[% END %]
 1;
-[% c.class_documentation_template | eval %]
+[% c.callclass_documentation_template | eval %]
 #);
 
   has callresult_class_template => (is => 'ro', isa => 'Str', default => q#
 [%- operation = c.result_for_operation(op_name) %]
 [%- shape = c.result_for_operation(op_name) %]
+[%- op_name = c.shapename_for_operation_output(op_name) %]
 [%- IF (shape) %]
-package [% c.api %]::[% c.shapename_for_operation_output(op_name) %];
+package [% c.api %]::[% op_name %];
   use Moose;
 [% FOREACH param_name IN shape.members.keys.sort -%]
   [%- member = c.shape(shape.members.$param_name.shape) -%]
@@ -58,7 +59,7 @@ package [% c.api %]::[% c.shapename_for_operation_output(op_name) %];
   [%- END -%]
 [%- END %]
 1;
-[% c.callclass_documentation_template | eval %]
+[% c.class_documentation_template | eval %]
 #);
 
   has service_class_template => (is => 'ro', isa => 'Str', default => q#


### PR DESCRIPTION
 - Use the op name for the call class name
 - Use the call class template for call documetation
 - Use the generic class template for the result documentation

Fixes #103 once the affected services are regenerated.