### PR TITLE
CopyObject fix and zero size file upload to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ nytprof.out
 pm_to_blib
 cpanfile.snapshot
 .carmel
+.DS_Store

--- a/lib/Paws/Net/APIRequest.pm
+++ b/lib/Paws/Net/APIRequest.pm
@@ -5,7 +5,7 @@ package Paws::Net::APIRequest;
 
   has parameters => (is => 'rw', isa => 'HashRef', default => sub { {} });
   has headers    => (is => 'rw', isa => 'HTTP::Headers', default => sub { HTTP::Headers->new });
-  has content    => (is => 'rw', isa => 'Str');
+  has content    => (is => 'rw', isa => 'Str|Undef');
   has method     => (is => 'rw', isa => 'Str');
   has uri        => (is => 'rw', isa => 'Str');
   has url        => (is => 'rw', isa => 'Str');

--- a/lib/Paws/Net/S3APIRequest.pm
+++ b/lib/Paws/Net/S3APIRequest.pm
@@ -66,9 +66,9 @@ package Paws::Net::S3APIRequest;
 
   has 'content_length' => (
     is       => 'ro',
-    isa      => 'Int',
+    isa      => 'Int|Undef',
     lazy     => 1,
-    default  => sub { length( shift->content ) }
+    default  => sub { length( shift->content || q[] ) }
   );
 
   sub _trim {

--- a/lib/Paws/Net/S3Signature.pm
+++ b/lib/Paws/Net/S3Signature.pm
@@ -12,15 +12,13 @@ package Paws::Net::S3Signature;
       $request->header( 'X-Amz-Security-Token' => $self->session_token );
     }
 
-    if ($request->content) { # && !$request->content_md5) {
-      my $hasher = Crypt::Digest::SHA256->new;
-      $hasher->add($request->content);
-      $request->header('X-Amz-Content-Sha256' => $hasher->hexdigest);
-    } else {
-      $request->header('X-Amz-Content-Sha256' => 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD' );
-    }
+    my $hasher = Crypt::Digest::SHA256->new;
+    $hasher->add($request->content || q[]);
+    $request->header('X-Amz-Content-Sha256' => $hasher->hexdigest);
 
+    # AWS prefers X-Amz-Date but Net::Amazon::Signature::V4 only handles Date in the headerpackage Paws::Net::S3Signature;
     $request->header( 'Date' => $request->{'date'} );
+
     $request->header( 'Host' => $self->endpoint_host );
 
     my $sig = Net::Amazon::Signature::V4->new( $self->access_key, $self->secret_key, $self->region, $self->service );


### PR DESCRIPTION
- Ignore .DS_Store files generated by Mac OSX systems
- Accept undefined content for APIRequest but default to empty string
- Accept undefined content-length but default to 0 size
- Fix S3 API headers
