### PR TITLE
Capture and set _request_id

### DIFF
--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -317,9 +317,10 @@ package Paws::API::Builder {
 
 [% c.doc_for_param_name_in_shape(shape, param_name) %]
 
-[% IF member.enum %]Valid values are: [% FOR value=member.enum %]C<"[% value %]">[% IF NOT loop.last %], [% END %][% END %][% END -%]
+[% IF member.enum %]Valid values are: [% FOR value=member.enum %]C<"[% value %]">[% IF NOT loop.last %], [% END %][% END %][% END -%][% END -%]
 
-[% END %]
+=head2 _request_id => Str
+
 
 =cut
 #);

--- a/builder-lib/Paws/API/Builder/EC2.pm
+++ b/builder-lib/Paws/API/Builder/EC2.pm
@@ -34,7 +34,10 @@ package [% c.api %]::[% operation.name %];
   use MooseX::ClassAttribute;
 
   class_has _api_call => (isa => 'Str', is => 'ro', default => '[% op_name %]');
-  class_has _returns => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% c.api %]::[% c.shapename_for_operation_output(op_name) %]'[% END %]);
+  class_has _returns => (isa => 'Str', is => 'ro', default => '
+    [%- IF (operation.output.keys.size) -%]
+      [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
+    [%- ELSE -%]Paws::API::Response[% END -%]');
   class_has _result_key => (isa => 'Str', is => 'ro');
 1;
 [% c.callclass_documentation_template | eval %]

--- a/builder-lib/Paws/API/Builder/json.pm
+++ b/builder-lib/Paws/API/Builder/json.pm
@@ -76,7 +76,10 @@ package [% c.api %]::[% operation.name %];
   use MooseX::ClassAttribute;
 
   class_has _api_call => (isa => 'Str', is => 'ro', default => '[% op_name %]');
-  class_has _returns => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% c.api %]::[% c.shapename_for_operation_output(op_name) %]'[% END %]);
+  class_has _returns => (isa => 'Str', is => 'ro', default => '
+    [%- IF (operation.output.keys.size) -%]
+      [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
+    [%- ELSE -%]Paws::API::Response[% END -%]');
   class_has _result_key => (isa => 'Str', is => 'ro');
 1;
 [% c.callclass_documentation_template | eval %]

--- a/builder-lib/Paws/API/Builder/query.pm
+++ b/builder-lib/Paws/API/Builder/query.pm
@@ -26,7 +26,10 @@ package [% c.api %]::[% operation.name %];
   use MooseX::ClassAttribute;
 
   class_has _api_call => (isa => 'Str', is => 'ro', default => '[% op_name %]');
-  class_has _returns => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% c.api %]::[% c.shapename_for_operation_output(op_name) %]'[% END %]);
+  class_has _returns => (isa => 'Str', is => 'ro', default => '
+    [%- IF (operation.output.keys.size) -%]
+      [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
+    [%- ELSE -%]Paws::API::Response[% END -%]');
   class_has _result_key => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% op_name %]Result'[% END %]);
 1;
 [% c.callclass_documentation_template | eval %]

--- a/builder-lib/Paws/API/Builder/restjson.pm
+++ b/builder-lib/Paws/API/Builder/restjson.pm
@@ -70,7 +70,10 @@ package [% c.api %]::[% operation.name %];
   class_has _api_call => (isa => 'Str', is => 'ro', default => '[% op_name %]');
   class_has _api_uri  => (isa => 'Str', is => 'ro', default => '[% operation.http.requestUri %]');
   class_has _api_method  => (isa => 'Str', is => 'ro', default => '[% operation.http.method %]');
-  class_has _returns => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% c.api %]::[% c.shapename_for_operation_output(op_name) %]'[% END %]);
+  class_has _returns => (isa => 'Str', is => 'ro', default => '
+    [%- IF (operation.output.keys.size) -%]
+      [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
+    [%- ELSE -%]Paws::API::Response[% END -%]');
   class_has _result_key => (isa => 'Str', is => 'ro');
 1;
 [% c.callclass_documentation_template | eval %]

--- a/builder-lib/Paws/API/Builder/restxml.pm
+++ b/builder-lib/Paws/API/Builder/restxml.pm
@@ -48,7 +48,10 @@ package [% c.api %]::[% op_name %];
   class_has _api_call => (isa => 'Str', is => 'ro', default => '[% op_name %]');
   class_has _api_uri  => (isa => 'Str', is => 'ro', default => '[% operation.http.requestUri %]');
   class_has _api_method  => (isa => 'Str', is => 'ro', default => '[% operation.http.method %]');
-  class_has _returns => (isa => 'Str', is => 'ro'[% IF (operation.output.keys.size) %], default => '[% c.api %]::[% c.shapename_for_operation_output(op_name) %]'[% END %]);
+  class_has _returns => (isa => 'Str', is => 'ro', default => '
+    [%- IF (operation.output.keys.size) -%]
+      [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
+    [%- ELSE -%]Paws::API::Response[% END -%]');
   class_has _result_key => (isa => 'Str', is => 'ro');
   [% IF (stream_param) %]class_has _stream_param => (is => 'ro', default => '[% stream_param %]');[% END %]
 1;

--- a/lib/Paws/API/Caller.pm
+++ b/lib/Paws/API/Caller.pm
@@ -95,15 +95,15 @@ package Paws::API::Caller;
     my ($self, $unserialized_struct, $call_object, $http_status, $content, $headers) = @_;
 
     $call_object = $call_object->meta->name;
+    my $request_id = $headers->{'x-amz-request-id'} 
+                      || $headers->{'x-amzn-requestid'}
+                      || $unserialized_struct->{'requestId'} 
+                      || $unserialized_struct->{'RequestId'} 
+                      || $unserialized_struct->{'RequestID'}
+                      || $unserialized_struct->{ ResponseMetadata }->{ RequestId };
+
 
     if ($call_object->_returns){
-      my $request_id = $headers->{'x-amz-request-id'} 
-                       || $headers->{'x-amzn-requestid'}
-                       || $unserialized_struct->{'requestId'} 
-                       || $unserialized_struct->{'RequestId'} 
-                       || $unserialized_struct->{'RequestID'}
-                       || $unserialized_struct->{ ResponseMetadata }->{ RequestId };
-
       if ($call_object->_result_key){
         $unserialized_struct = $unserialized_struct->{ $call_object->_result_key };
       }

--- a/lib/Paws/API/Response.pm
+++ b/lib/Paws/API/Response.pm
@@ -1,0 +1,18 @@
+
+package Paws::API::Response;
+  use Moose;
+  has _request_id => (is => 'ro', isa => 'Str');
+1;
+
+### main pod documentation begin ###
+
+=head1 NAME
+
+Paws::API::Response
+
+=head1 ATTRIBUTES
+
+=head2 _request_id => Str
+
+=cut
+


### PR DESCRIPTION
 Set _request_id for all Paws service methods that do not return Paws service objects in a generic Paws::API::Response object 
