### PR TITLE
Use Digest::SHA instead of Crypt::Digest::SHA256

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ requires 'URL::Encode::XS';
 requires 'URI::Template';
 requires 'Digest::HMAC';
 requires 'Config::INI';
-requires 'Crypt::Digest::SHA256';
+requires 'Digest::SHA';
 # For the paws CLI
 requires 'Hash::Flatten';
 requires 'MooseX::Getopt';

--- a/cpanfile
+++ b/cpanfile
@@ -15,7 +15,6 @@ requires 'DateTime::Format::ISO8601';
 requires 'URL::Encode';
 requires 'URL::Encode::XS';
 requires 'URI::Template';
-requires 'Digest::HMAC';
 requires 'Config::INI';
 requires 'Digest::SHA';
 # For the paws CLI

--- a/lib/Paws/Net/S3Signature.pm
+++ b/lib/Paws/Net/S3Signature.pm
@@ -2,7 +2,7 @@ package Paws::Net::S3Signature;
   use Moose::Role;
   requires 'service';
 
-  use Crypt::Digest::SHA256;
+  use Digest::SHA;
   use Net::Amazon::Signature::V4;
 
   sub sign {
@@ -12,7 +12,7 @@ package Paws::Net::S3Signature;
       $request->header( 'X-Amz-Security-Token' => $self->session_token );
     }
 
-    my $hasher = Crypt::Digest::SHA256->new;
+    my $hasher = Digest::SHA->new(256);
     $hasher->add($request->content || q[]);
     $request->header('X-Amz-Content-Sha256' => $hasher->hexdigest);
 


### PR DESCRIPTION
Digest::SHA is core and supports SHA-256, this removes the dependency on CryptX.