### PR TITLE
Update RestXmlCaller.pm to fix malformed xml schema issues for Paws::S3::PutBucketNotificationConfiguration

### DIFF
--- a/lib/Paws/Net/RestXmlCaller.pm
+++ b/lib/Paws/Net/RestXmlCaller.pm
@@ -107,15 +107,30 @@ package Paws::Net::RestXmlCaller;
       my $att_name = $attribute->name;
       next if (not $attribute->has_value($value));
       if (Moose::Util::find_meta($attribute->type_constraint->name)) {
-        $xml .= sprintf '<%s>%s</%s>', $att_name, $self->_to_xml($attribute->get_value($value)), $att_name;
+        if ($attribute->does('Unwrapped')) {
+          my $location = $attribute->xmlname;
+          $xml .= sprintf '<%s>%s</%s>', $location, $self->_to_xml($attribute->get_value($value)), $location;
+        } else {
+          $xml .= sprintf '<%s>%s</%s>', $att_name, $self->_to_xml($attribute->get_value($value)), $att_name;
+        }
       } elsif ($attribute->type_constraint eq 'ArrayRef[Str|Undef]') {
           my $location = $attribute->does('NameInRequest') ? $attribute->request_name : $att_name;
-          $xml .= "<${att_name}>" . ( join '', map { sprintf '<%s>%s</%s>', $location, $_, $location } @{ $attribute->get_value($value) } ) . "</${att_name}>";
+          if ($attribute->does('Unwrapped')) {
+            $location = $attribute->xmlname;
+            $xml .=  ( join '', map { sprintf '<%s>%s</%s>', $location, $_, $location } @{ $attribute->get_value($value) } );
+          } else {
+            $xml .= "<${att_name}>" . ( join '', map { sprintf '<%s>%s</%s>', $location, $_, $location } @{ $attribute->get_value($value) } ) . "</${att_name}>";
+          }
       } elsif ($attribute->type_constraint =~ m/^ArrayRef\[(.*?\:\:.*)\]/) { #assume it's an array of Paws API objects
         my $location = $attribute->does('Unwrapped') ? $attribute->xmlname : $att_name;
         $xml .=  ( join '', map { sprintf '<%s>%s</%s>', $location, $self->_to_xml($_), $location } @{ $attribute->get_value($value) } );
       } else {
-        $xml .= sprintf '<%s>%s</%s>', $att_name, $attribute->get_value($value), $att_name;
+        if ($attribute->does('Unwrapped')) {
+          my $location = $attribute->xmlname;
+          $xml .=  sprintf '<%s>%s</%s>', $location, $attribute->get_value($value), $location;
+        } else {
+          $xml .= sprintf '<%s>%s</%s>', $att_name, $attribute->get_value($value), $att_name;
+        }
       }
     }
     return $xml; 


### PR DESCRIPTION
Set the correct XML element names where indicated by the schema. (See 'Events'=>'Event' and 'LambdaFunctionArn'=>'CloudFunction' of Paws::S3::LambdaFunctionConfiguration)