### PR TITLE
Fix Issue #131: S3 Metadata

### DIFF
--- a/builder-lib/Paws/API/Builder/restxml.pm
+++ b/builder-lib/Paws/API/Builder/restxml.pm
@@ -39,6 +39,7 @@ package [% c.api %]::[% op_name %];
   [%- traits = [] -%]
   has [% param_name %] => (is => 'ro', isa => '[% member.perl_type %]'
   [%-    IF (shape.members.$param_name.location == 'header');      traits.push('ParamInHeader') %], header_name => '[% shape.members.$param_name.locationName %]'
+  [%- ELSIF (shape.members.$param_name.location == 'headers');     traits.push('ParamInHeaders') %], header_prefix => '[% shape.members.$param_name.locationName %]'
   [%- ELSIF (shape.members.$param_name.location == 'querystring'); traits.push('ParamInQuery') %], query_name => '[% shape.members.$param_name.locationName %]'
   [%- ELSIF (shape.members.$param_name.location == 'uri');         traits.push('ParamInURI') %], uri_name => '[% shape.members.$param_name.locationName %]'
   [%- ELSIF (shape.members.$param_name.streaming == 1);            traits.push('ParamInBody'); %][% stream_param = param_name -%]

--- a/builder-lib/Paws/API/Builder/restxml.pm
+++ b/builder-lib/Paws/API/Builder/restxml.pm
@@ -79,6 +79,7 @@ package [% c.api %]::[% op_name %];
   has [% param_name %] => (is => 'ro', isa => '[% member.perl_type %]'
   [%- IF (shape.members.$param_name.locationName) %]
     [%- IF (shape.members.$param_name.location == 'header') %], traits => ['ParamInHeader'], header_name => '[% shape.members.$param_name.locationName -%]'
+    [%- ELSIF (shape.members.$param_name.location == 'headers') %], traits => ['ParamInHeaders'], header_prefix => '[% shape.members.$param_name.locationName %]'
     [%- ELSIF (shape.members.$param_name.location == 'querystring') %], traits => ['ParamInQuery'], query_name => '[% shape.members.$param_name.locationName -%]' 
     [%- ELSIF (shape.members.$param_name.location == 'uri') %], traits => ['ParamInURI'], uri_name => '[% shape.members.$param_name.locationName -%]' 
     [%- ELSE %], traits => ['Unwrapped'], xmlname => '[% shape.members.$param_name.locationName %]'[%- END -%][%- END -%]

--- a/lib/Paws/API.pm
+++ b/lib/Paws/API.pm
@@ -33,4 +33,9 @@ package Paws::API::Attribute::Trait::ParamInURI;
   Moose::Util::meta_attribute_alias('ParamInURI');
   has uri_name => (is => 'ro', isa => 'Str');
 
+package Paws::API::Attribute::Trait::ParamInHeaders;
+  use Moose::Role;
+  use Moose::Util;
+  Moose::Util::meta_attribute_alias('ParamInHeaders');
+  has header_prefix => (is => 'ro', isa => 'Str');
 1;

--- a/lib/Paws/API/Caller.pm
+++ b/lib/Paws/API/Caller.pm
@@ -141,8 +141,16 @@ package Paws::API::Caller;
     #  my $extracted_val = $result->{ $key };
     #  print STDERR "RESULT >>> $extracted_val\n";
 
+      # Free-form paramaters passed in the HTTP headers
+      if ($meta->does('Paws::API::Attribute::Trait::ParamInHeaders')) { 
+        Paws->load_class("$att_type");
+        my $att_class        = $att_type->class;
+        my $header_prefix    = $meta->header_prefix;
+        my @metadata_headers = grep /^$header_prefix/, keys %{$result};
+        $args{ $att }        = $att_class->new( Map => { map { $_ => $result->{$_} } @metadata_headers } ); 
+      }
       # We'll consider that an attribute without brackets [] isn't an array type
-      if ($att_type !~ m/\[.*\]$/) {
+      elsif ($att_type !~ m/\[.*\]$/) {
         my $value = $result->{ $key };
         my $value_ref = ref($value);
 


### PR DESCRIPTION
This addresses [issue 131](https://github.com/pplu/aws-sdk-perl/issues/131) by adding a Trait, "ParamsInHeader" for free-form AWS parameters that are passed in the request header (e.g. S3 Metadata). The REST XML request builder is updated to look for that trait and act accordingly. 

Testing done: I created a sketch with my company's AWS credentials and was able to put an object with S3 metadata specified, like so:

```
    use 5.016;
    use FindBin qw($Bin);
    use lib qq($Bin/../auto-lib);
    use lib qq{$Bin/../lib};
    use Paws;

    # AWS credentials in %ENV
    my $s3 = Paws->service('S3', region => 'us-east-1');
    my $bucket = 'mah-bukkit';
    my $key = 'Paws-test-foobar';
    my $data = 'my data';

    $s3->PutObject( Bucket => $bucket, Key => $key, Body => $data, Metadata => { filename => 'foobar.doc' } );
    my $object = $s3->GetObject( Bucket => $bucket, Key => $key );
    use DDP;
    p $object;
    say 'metadata:';
    p $object->Metadata;
```

```
Paws::S3::GetObjectOutput  {
    Parents       Moose::Object
    public methods (29) : AcceptRanges, Body, CacheControl, ContentDisposition, ContentEncoding, ContentLanguage, ContentLength, ContentRange, ContentType, DeleteMarker, ETag, Expiration, Expires, LastModified, meta, Metadata, MissingMeta, PartsCount, ReplicationStatus, RequestCharged, Restore, ServerSideEncryption, SSECustomerAlgorithm, SSECustomerKeyMD5, SSEKMSKeyId, StorageClass, TagCount, VersionId, WebsiteRedirectLocation
    private methods (2) : _request_id, _stream_param
    internals: {
        _request_id     "2DD05179C822C868",
        AcceptRanges    "bytes",
        Body            "my data",
        ContentLength   7,
        ContentType     "application/octet-stream",
        ETag            ""1291e1c0aa879147f51f4a279e7c2e55"",
        LastModified    "Sat, 04 Mar 2017 05:37:08 GMT",
        Metadata        Paws::S3::Metadata
    }
}
metadata:
Paws::S3::Metadata  {
    Parents       Moose::Object
    public methods (4) : Map, meta, xml_keys, xml_values
    private methods (0)
    internals: {
        Map   {
            x-amz-meta-filename   "foobar.doc"
        }
    }
}
```