### PR TITLE
Fix Issue 154: blank ETag after asynchronous PutObject

### DIFF
--- a/lib/Paws/Net/RestXMLResponse.pm
+++ b/lib/Paws/Net/RestXMLResponse.pm
@@ -35,7 +35,7 @@ package Paws::Net::RestXMLResponse;
 
     # Set respones headers attributes
     foreach my $key (keys %$headers){
-      $unserialized_struct->{$key} = $headers->{$key};
+      $unserialized_struct->{lc $key} = $headers->{$key};
     }
  
     if ( $http_status >= 300 ) {


### PR DESCRIPTION
How to test:

```perl
my $s3 = Paws->new( 
    config => { 
        region => 'us-east-1', 
        caller => Paws::Net::MojoAsyncCaller->new,
    }
);
my $future = $s3->put(
    Bucket => 'daisy', 
    Key => 'foobar', 
    Body => 'foo bar baz bak',
);
$future->on_done( sub { say shift->ETag } ); # Outputs an e-tag
```

I got an ETag. :) 