### PR TITLE
Speed up Credential Refreshing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 0.32
+ - Speed up Credential Refreshing (Arthur Axel fREW Schmidt)
  - Bug fixed: Issue #105. Some API calls where not correctly handling parameters specified in their URI.
    Notably, this fixes S3 ListObjectsV2. (dakkar)
  - New API: LexRuntime

--- a/lib/Paws/Credential/AssumeRole.pm
+++ b/lib/Paws/Credential/AssumeRole.pm
@@ -1,16 +1,13 @@
 package Paws::Credential::AssumeRole;
   use Moose;
-  use DateTime;
   use DateTime::Format::ISO8601;
   with 'Paws::Credential';
 
   has expiration => (
     is => 'rw',
-    isa => 'DateTime',
+    isa => 'Int',
     lazy => 1,
-    default => sub {
-      DateTime->from_epoch(epoch => 0); # need a better way to do this
-    }
+    default => sub { 0 }
   );
 
   has actual_creds => (is => 'rw');
@@ -50,7 +47,7 @@ package Paws::Credential::AssumeRole;
   sub _refresh {
     my $self = shift;
 
-    return if (($self->expiration - DateTime->now())->is_positive);
+    return if $self->expiration >= time;
 
     my $result = $self->sts->AssumeRole(
       RoleSessionName => $self->RoleSessionName,
@@ -61,7 +58,7 @@ package Paws::Credential::AssumeRole;
     );
 
     my $creds = $self->actual_creds($result->Credentials);
-    $self->expiration(DateTime::Format::ISO8601->parse_datetime($result->Credentials->Expiration));
+    $self->expiration(DateTime::Format::ISO8601->parse_datetime($result->Credentials->Expiration)->epoch);
   }
 
   no Moose;

--- a/lib/Paws/Credential/InstanceProfile.pm
+++ b/lib/Paws/Credential/InstanceProfile.pm
@@ -1,7 +1,6 @@
 package Paws::Credential::InstanceProfile;
   use JSON::MaybeXS;
   use Moose;
-  use DateTime;
   use DateTime::Format::ISO8601;
   with 'Paws::Credential';
 
@@ -28,10 +27,8 @@ package Paws::Credential::InstanceProfile;
 
   has expiration => (
     is => 'rw',
-    isa => 'DateTime',
-    default => sub {
-      DateTime->from_epoch(epoch => 0); # need a better way to do this
-    }
+    isa => 'Int',
+    default => sub { 0 }
   );
 
   has actual_creds => (is => 'rw', default => sub { {} });
@@ -58,7 +55,7 @@ package Paws::Credential::InstanceProfile;
   sub _refresh {
     my $self = shift;
 
-    return if (($self->expiration - DateTime->now())->is_positive);
+    return if $self->expiration >= time;
 
     my $ua = $self->ua;
     my $r = $ua->get($self->metadata_url);
@@ -72,7 +69,7 @@ package Paws::Credential::InstanceProfile;
     if ($@) { die "Error in JSON from metadata URL" }
 
     $self->actual_creds($json);
-    $self->expiration(DateTime::Format::ISO8601->parse_datetime($json->{Expiration}));
+    $self->expiration(DateTime::Format::ISO8601->parse_datetime($json->{Expiration})->epoch);
   }
 
   no Moose;

--- a/lib/Paws/Credential/STS.pm
+++ b/lib/Paws/Credential/STS.pm
@@ -1,16 +1,13 @@
 package Paws::Credential::STS;
   use Moose;
-  use DateTime;
   use DateTime::Format::ISO8601;
   with 'Paws::Credential';
 
   has expiration => (
     is => 'rw',
-    isa => 'DateTime',
+    isa => 'Int',
     lazy => 1,
-    default => sub {
-      DateTime->from_epoch(epoch => 0); # need a better way to do this
-    }
+    default => sub { 0 }
   );
 
   has actual_creds => (is => 'rw');
@@ -47,7 +44,7 @@ package Paws::Credential::STS;
   sub _refresh {
     my $self = shift;
 
-    return if (($self->expiration - DateTime->now())->is_positive);
+    return if $self->expiration >= time;
 
     my $result = $self->sts->GetFederationToken(
       Name => $self->Name,
@@ -56,7 +53,7 @@ package Paws::Credential::STS;
     );
 
     my $creds = $self->actual_creds($result->Credentials);
-    $self->expiration(DateTime::Format::ISO8601->parse_datetime($result->Credentials->Expiration));
+    $self->expiration(DateTime::Format::ISO8601->parse_datetime($result->Credentials->Expiration)->epoch);
   }
 
   no Moose;


### PR DESCRIPTION
In my tests this improved speed on each api call by a little under a millisecond.

Would close #158 