### PR TITLE
Route53

### DIFF
--- a/Changes
+++ b/Changes
@@ -392,7 +392,7 @@
  - KMS API update: New operations: CancelKeyDeletion ListRetirableGrants ScheduleKeyDeletion and docu update
 
 0.16 09 Oct 2015
- - docu fixes by Gimpson
+ - docu fixes by BeerBikesBBQ
  - Timeout for all user agents set to 60 seconds. Will be configurable soon
  - S3 Update: Support for S3 Standard - Infrequent Access 
  - CloudWatchLogs Update: Export tasks

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ CloudFront and Route53, help with number stringification
 
 stevecaldwell77 for contributing support for temporary credentials in S3
 
-Gimpson for contributing documentation fixes
+Ryan Olson (BeerBikesBBQ) for contributing documentation fixes
 
 Roger Pettett for testing and contributing fixes for tests on MacOSX
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ make gen-classes
 Perl versions
 ============
 
-The SDK is targeted at modern Perl versions. Since a new perl gets released every year, distributions perl tend to lag behind, so 
+The SDK is targeted at modern Perl versions. Since a new perl gets released every year, distributions perl tend to lag behind, so
 support for perl versions on any modern, widespread distribution is our target.
-Vert old versions may work, but no intention to support them is made. You can always install a modern version of perl with perlbrew or
+Very old versions may work, but no intention to support them is made. You can always install a modern version of perl with perlbrew or
 plenv in a breeze. We're running the test cases on Travis for all "supported" perl versions. If you want to support a lower version,
 you can contribute back. Acceptance of patches for older versions of Perl won't mean that the compatibility will be maintained
 long-term, although it will be tried :).

--- a/auto-lib/Paws.pm
+++ b/auto-lib/Paws.pm
@@ -674,7 +674,7 @@ CloudFront and Route53, help with number stringification
 
 stevecaldwell77 for contributing support for temporary credentials in S3
 
-Gimpson for contributing documentation fixes
+Ryan Olson (BeerBikesBBQ) for contributing documentation fixes
 
 Roger Pettett for testing and contributing fixes for tests on MacOSX
 

--- a/t/05_service_calls.t
+++ b/t/05_service_calls.t
@@ -562,4 +562,27 @@ $request = $r53->ListHealthChecks(
 like($request->url, qr/marker=X/, 'marker with correct name in URL');
 like($request->url, qr/maxitems=50/, 'maxitems with correct name in URL');
 
+$request = $r53->ChangeResourceRecordSets(
+  HostedZoneId => 'A999AAA999AAA',
+  ChangeBatch  => {
+    Changes => [
+      {
+        Action            => 'UPSERT',
+        ResourceRecordSet => {
+          Name => 'testname.example.com',
+          TTL  => 60,
+          Type => 'CNAME',
+          ResourceRecords => [{
+              Value => '10.0.0.1',
+          }],
+        },
+      },
+    ],
+  },
+);
+
+$ref = XMLin($request->content);
+
+like($request->url, qr|hostedzone/A999AAA999AAA/rrset|, 'URL has the HostedZoneId');
+
 done_testing;

--- a/t/lib/Paws/JsonParamsService.pm
+++ b/t/lib/Paws/JsonParamsService.pm
@@ -13,6 +13,8 @@ package Paws::JsonParamsService;
   has retriables => (is => 'ro', isa => 'ArrayRef', default => sub { [
   ] });
 
+  sub operations { qw/Method1 Method2/ }
+
   with 'Paws::API::Caller', 'Paws::API::EndpointResolver', 'Paws::Net::V4Signature', 'Paws::Net::JsonCaller', 'Paws::Net::JsonResponse';
 
   sub Method1 {

--- a/t/lib/Paws/QueryFlattenedParamsService.pm
+++ b/t/lib/Paws/QueryFlattenedParamsService.pm
@@ -13,6 +13,8 @@ package Paws::QueryFlattenedParamsService;
        sub { defined $_[0]->http_status and $_[0]->http_status == 403 and $_[0]->code eq 'RequestThrottled' },
   ] });
 
+  sub operations { return () }
+
   with 'Paws::API::Caller', 'Paws::API::EndpointResolver', 'Paws::Net::V4Signature', 'Paws::Net::QueryCaller', 'Paws::Net::XMLResponse';
 
   sub Method2 {

--- a/t/lib/Paws/QueryParamsService.pm
+++ b/t/lib/Paws/QueryParamsService.pm
@@ -14,6 +14,8 @@ package Paws::QueryParamsService;
 
   with 'Paws::API::Caller', 'Paws::API::EndpointResolver', 'Paws::Net::V4Signature', 'Paws::Net::QueryCaller', 'Paws::Net::XMLResponse';
 
+  sub operations { return () }
+
   sub Method2 {
     my $self = shift;
     my $call_object = $self->new_with_coercions('Paws::JsonParamsService::Method2', @_);

--- a/t/lib/Paws/RestJsonParamsService.pm
+++ b/t/lib/Paws/RestJsonParamsService.pm
@@ -15,6 +15,8 @@ package Paws::RestJsonParamsService;
 
   with 'Paws::API::Caller', 'Paws::API::EndpointResolver', 'Paws::Net::V4Signature', 'Paws::Net::RestJsonCaller', 'Paws::Net::RestJsonResponse';
 
+  sub operations { return () };
+
   sub Method1 {
     my $self = shift;
     my $call_object = $self->new_with_coercions('Paws::JsonParamsService::Method1', @_);


### PR DESCRIPTION
The meat of this partial fix for Route53 is in lib/Paws/Net/RestXmlCaller.pm. The problem is that the ChangeResourceRecordSet call puts a param in the URI, but the param in the URI template is "Id", but the attribute is HostedZoneId (which has uri_name set to Id). Previous code expected the attribute name and uri_name to be the same. 

I have a few doc fixes and unrelated test fixes in this branch as well, I'm happy to pull those apart into separate pull requests if that makes your life easier.

The fix in 6672e7d gets past the original error (Can't call method "does" on an undefined value at /usr/local/share/perl/5.14.2/Paws/Net/RestXmlCaller.pm line 65.) However, the request then fails with:

`<?xml version="1.0"?><ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><Error><Type>Sender</Type><Code>MalformedInput</Code><Message>ChangeBatch is not valid, expected ChangeResourceRecordSetsRequest</Message></Error><RequestId>676beb72-2457-11e7-be19-25d44cd5d642</RequestId></ErrorResponse>
`

It looks to me like the XML request being sent is not wrapped in a `<ChangeResourceRecordSetsRequest></ChangeResourceRecordSetsRequest>`, I assume that's the problem, but that's where I ran out of time to work on this for now. Hopefully I can get back to poking at it later this week or early next week, but wanted to share this out in case it's of use or you can tell me I'm going down the wrong path.