### PR TITLE
prevent empty messages as type is defined as string

### DIFF
--- a/lib/Paws/Net/RestJsonResponse.pm
+++ b/lib/Paws/Net/RestJsonResponse.pm
@@ -70,7 +70,7 @@ package Paws::Net::RestJsonResponse;
     $request_id = $headers->{ 'x-amzn-requestid' };
 
     Paws::Exception->new(
-      message => $message,
+      message => $message // '',
       code => $code,
       request_id => $request_id,
       http_status => $http_status,


### PR DESCRIPTION
e.g. EFS DeleteFileSystem errors have no message