### PR TITLE
Handle missing code and response ID in errors

### DIFF
--- a/lib/Paws/Net/JsonResponse.pm
+++ b/lib/Paws/Net/JsonResponse.pm
@@ -58,11 +58,11 @@ package Paws::Net::JsonResponse;
       }
     }
 
-    my $code = $struct->{__type};
+    my $code = $struct->{__type} // 'UnrecognizedError';
     if ($code =~ m/#/) {
       $code = (split /#/, $code)[1];
     }
-    $request_id = $headers->{ 'x-amzn-requestid' };
+    $request_id = $headers->{ 'x-amzn-requestid' } // '';
 
     Paws::Exception->new(
       message => $message,

--- a/lib/Paws/Net/RestJsonResponse.pm
+++ b/lib/Paws/Net/RestJsonResponse.pm
@@ -67,7 +67,7 @@ package Paws::Net::RestJsonResponse;
     } else {
       $code = 'UnrecognizedError';
     }
-    $request_id = $headers->{ 'x-amzn-requestid' };
+    $request_id = $headers->{ 'x-amzn-requestid' } // '';
 
     Paws::Exception->new(
       message => $message,

--- a/lib/Paws/Net/RestXMLResponse.pm
+++ b/lib/Paws/Net/RestXMLResponse.pm
@@ -45,11 +45,8 @@ package Paws::Net::RestXMLResponse;
 
     $message = status_message($http_status);
     $code = $http_status;
-    $request_id = $headers->{ 'x-amz-request-id' };
+    $request_id = $headers->{ 'x-amz-request-id' } // $struct->{RequestId} // '';
     $host_id = $headers->{ 'x-amz-id-2' };
-
-    # Find in the body if it's not in headers
-    $request_id = $struct->{ RequestId } if (not defined $request_id);
 
     Paws::Exception->new(
       message => $message,


### PR DESCRIPTION
This fixes retries on 503 errors that don't have an `x-amzn-requestid` header or a `__type` attribute.