### PR TITLE
Add convenience links to service on call docs

### DIFF
--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -334,7 +334,7 @@ package Paws::API::Builder {
 
 =head1 NAME
 
-[% c.api %]::[% op_name %] - Arguments for method [% op_name %] on [% c.api %]
+[% c.api %]::[% op_name %] - Arguments for method [% op_name %] on L<[% c.api %]>
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
For convenience, provide a link to ease going back to the service page when checking a given call documentation.