### PR TITLE
Only set ContentMD5 header when content has been set

### DIFF
--- a/lib/Paws/Net/RestXmlCaller.pm
+++ b/lib/Paws/Net/RestXmlCaller.pm
@@ -227,14 +227,14 @@ package Paws::Net::RestXmlCaller;
       $request->content($xml_body);
     }
 
-    $self->_to_header_params($request, $call);
-
     if ($call->can('_stream_param')) {
       my $param_name = $call->_stream_param;
       $request->content($call->$param_name);
       $request->headers->header( 'content-length' => $request->content_length );
       #$request->headers->header( 'content-type'   => $self->content_type );
     }
+
+    $self->_to_header_params($request, $call);
 
     $self->sign($request);
 


### PR DESCRIPTION
In the context of calling PutObject:

In lib/Paws/Net/RestXmlCaller.pm
```perl
    if (my $xml_body = $self->_to_xml_body($call)){
      $request->content($xml_body);
    }
```
sets the body to undef and then the next call `$self->_to_header_params($request, $call);` which calculates the MD5 checksum always calculates a checksum of the empty string.

This is because PutObject 
```perl
  class_has _stream_param => (is => 'ro', default => 'Body');
```
and so the content is only set in the code after `_to_header_params` is called

By moving the `_to_header_params` call to JUST BEFORE the `sign` call we can ensure that if there is content to digest it will have been set


PutObject is a *bread and butter* call. **PLEASE** consider pushing this out as a patched release with urgency 



