### PR TITLE
Make valid signatures for S3-alike services on non-default ports

### DIFF
--- a/lib/Paws/Net/S3Signature.pm
+++ b/lib/Paws/Net/S3Signature.pm
@@ -35,7 +35,10 @@ package Paws::Net::S3Signature;
     # AWS prefers X-Amz-Date but Net::Amazon::Signature::V4 only handles Date in the headerpackage Paws::Net::S3Signature;
     $request->header( 'Date' => $request->{'date'} );
 
-    $request->header( 'Host' => $self->endpoint_host );
+    $request->header(
+        'Host' => $self->endpoint->default_port == $self->endpoint->port
+        ? $self->endpoint->host
+        : $self->endpoint->host_port);
 
     my $sig = Net::Amazon::Signature::V4->new( $self->access_key, $self->secret_key, $self->region, $self->service );
     my $signed_req = $sig->sign( $request );


### PR DESCRIPTION
When trying to use Paws::S3 with an S3 compatible server (minio in this case)
which listens on a non-default http(s) port, invalid signatures are generated
because only the `host` part of the endpoint URI is used.

AWS and minio server side use `host:port` when the port isn't the
default port (443).

Confirmed behaviour with aws cli/boto and minio's python client.