### PR TITLE
add XML::Simple version dep

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -8,7 +8,7 @@ requires 'URI';
 requires 'Net::Amazon::Signature::V3';
 requires 'Net::Amazon::Signature::V4';
 requires 'JSON::MaybeXS';
-requires 'XML::Simple';
+requires 'XML::Simple' => '2.21';
 requires 'IO::Socket::SSL';
 requires 'DateTime';
 requires 'DateTime::Format::ISO8601';


### PR DESCRIPTION
Test t/25_error_on_malformed_response.t failing due to XML::Simple 2.20.
Updating to 2.21 allows it to pass.