### PR TITLE
Fix for failing Pod syntax tests, escape service name strings #225

### DIFF
--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -7,6 +7,9 @@ package Paws::API::Builder {
   use Template;
   use File::Slurper 'read_binary';
   use JSON::MaybeXS;
+  use Pod::Escapes();
+  use Data::Munge;
+      
   use v5.10;
 
   use Paws::API::RegionBuilder; 
@@ -488,9 +491,18 @@ package Paws::API::Builder {
     return $self->api . '::' . $shape;
   }
 
+  sub escape_pod {
+    my ($string) = @_;
+    my %char2names = reverse %Pod::Escapes::Name2character;
+    my $rekeys = list2re(keys %char2names);
+    $string =~ s/($rekeys)/E<$char2names{$1}>/g;
+    return $string;
+  }
+  
   sub process_template {
     my ($self, $template, $vars) = @_;
-    my $tt = Template->new(INCLUDE_PATH => $self->template_path);
+    my $tt = Template->new(INCLUDE_PATH => $self->template_path,
+        FILTERS => { escape_pod => \&escape_pod });
     my $output = '';
     $tt->process($template, $vars, \$output) || die $tt->error();
     return $output;

--- a/cpanfile
+++ b/cpanfile
@@ -55,6 +55,7 @@ on 'develop' => sub {
   requires 'EV';
   requires 'LWP::UserAgent';
   requires 'Furl';
+  requires 'Pod::Escapes';
 };
 on 'test' => sub {
   requires 'File::Slurper';

--- a/templates/default/callclass_documentation.tt
+++ b/templates/default/callclass_documentation.tt
@@ -7,7 +7,7 @@
 =head1 DESCRIPTION
 
 This class represents the parameters used for calling the method [% operation.name %] on the 
-L<[% c.api_struct.metadata.serviceFullName %]|[% c.api %]> service. Use the attributes of this class
+L<[% c.api_struct.metadata.serviceFullName | escape_pod %]|[% c.api %]> service. Use the attributes of this class
 as arguments to method [% operation.name %].
 
 You shouldn't make instances of this class. Each attribute should be used as a named argument in the call to [% operation.name %].


### PR DESCRIPTION
Service names are now properly escaped, adds Pod::Escapes and Data::Munge to the dependencies