### PR TITLE
Fix typo on Pod documentation

### DIFF
--- a/lib/Paws/Credential/Environment.pm
+++ b/lib/Paws/Credential/Environment.pm
@@ -22,7 +22,7 @@ Paws::Credential::Environment
   use Paws::Credential::Environment;
 
   my $paws = Paws->new(config => {
-    credentials => Paws::Credential::Enviroment->new
+    credentials => Paws::Credential::Environment->new
   });
 
 =head1 DESCRIPTION


### PR DESCRIPTION
POD documentation for Paws::Credential::Environment has typo, this changes it to actually match with the name of the package.