### PR TITLE
Implement the output of the credentials process scripts in pure Perl

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,5 @@
 0.38
- - 
+ - Fix test suite so that credentials_process tests don't need extra modules 
 
 0.37 13 Jun 2018
  - Big refactor of all result handling for all services

--- a/t/04_credentials/test_cred_process
+++ b/t/04_credentials/test_cred_process
@@ -1,10 +1,3 @@
 #!/usr/bin/env perl
 
-use JSON::MaybeXS;
-
-print encode_json({
-  AccessKeyId => 'PCAccessKey',
-  SecretAccessKey => 'PCSecretKey',
-  SessionToken => 'PCSessionToken',
-  Version => 1,
-});
+print '{"AccessKeyId":"PCAccessKey","SecretAccessKey":"PCSecretKey","SessionToken":"PCSessionToken","Version":1}';

--- a/t/04_credentials/test_cred_process.expiry
+++ b/t/04_credentials/test_cred_process.expiry
@@ -1,12 +1,3 @@
 #!/usr/bin/env perl
 
-use JSON::MaybeXS;
-
-print encode_json({
-  AccessKeyId => time,
-  SecretAccessKey => 'PCSecretKey',
-  SessionToken => 'PCSessionToken',
-  # A timestamp very in the past
-  Expiration => "2000-01-01T00:00:00Z",
-  Version => 1,
-});
+print '{"AccessKeyId":"' . time . '","SecretAccessKey":"PCSecretKey","SessionToken":"PCSessionToken","Version":1,"Expiration":"2000-01-01T00:00:00Z"}';

--- a/t/04_credentials/test_cred_process.fail
+++ b/t/04_credentials/test_cred_process.fail
@@ -1,11 +1,5 @@
 #!/usr/bin/env perl
 
-use JSON::MaybeXS;
-
-print encode_json({
-  AccessKeyId => 'PCAccessKey',
-  SecretAccessKey => 'PCSecretKey',
-  Version => 1,
-});
+print '{"AccessKeyId":"PCAccessKey","SecretAccessKey":"PCSecretKey","Version":1}';
 
 exit 1;

--- a/t/04_credentials/test_cred_process.noversion
+++ b/t/04_credentials/test_cred_process.noversion
@@ -1,8 +1,4 @@
 #!/usr/bin/env perl
 
-use JSON::MaybeXS;
+print '{"AccessKeyId":"PCAccessKey","SecretAccessKey":"PCSecretKey"}';
 
-print encode_json({
-  AccessKeyId => 'PCAccessKey',
-  SecretAccessKey => 'PCSecretKey',
-});


### PR DESCRIPTION
Paws 0.37 is failing lots of CPAN Testers: http://matrix.cpantesters.org/?dist=Paws+0.37

Fix test suite so that credentials_process tests don't need extra modules (sometimes the
perl being tested is not the same perl that #!/usr/bin/env perl returns, so it may not
have JSON::MaybeXS installed

Should solve #248 and #251
