### PR TITLE
Add mock caller which does not generate a response 

### DIFF
--- a/lib/Paws/Net/FileMockCaller.pm
+++ b/lib/Paws/Net/FileMockCaller.pm
@@ -92,7 +92,7 @@ package Paws::Net::FileMockCaller;
 
   sub caller_to_response {
     my ($self, $service, $call_object, $response) = @_;
- 
+
     return $self->real_caller->caller_to_response($service, $call_object, $response);   
   };
 

--- a/lib/Paws/Net/MockCaller.pm
+++ b/lib/Paws/Net/MockCaller.pm
@@ -8,6 +8,7 @@ package Paws::Net::MockCaller;
   use Moose::Util::TypeConstraints;
   use Path::Tiny;
   use Paws::Net::FileMockCaller;
+  use Paws::Net::NoResponseMockCaller;
 
   has real_caller => (
     is => 'ro', 
@@ -18,17 +19,25 @@ package Paws::Net::MockCaller;
     }
   );
 
+  has mock_type => (
+    is => 'ro',
+    isa => 'Str',
+    default => sub { 'FileMockCaller' },
+  );
+
   has mock_mode => (
     is => 'ro',
+    lazy => 1,
     isa => enum([ 'REPLAY', 'RECORD' ]),
-    required => 1,
+    required => 0,
     default => sub { $ENV{PAWS_MOCK_MODE} }
   );
 
   has mock_dir => (
     is => 'ro',
     isa => 'Str',
-    required => 1,
+    lazy => 1,
+    required => 0,
     default => sub { $ENV{PAWS_MOCK_DIR} }
   );
 
@@ -49,7 +58,8 @@ package Paws::Net::MockCaller;
     lazy => 1,
     default => sub {
       my $self = shift;
-      Paws::Net::FileMockCaller->new(
+      my $mock_class = 'Paws::Net::' . $self->mock_type;
+      $mock_class->new(
         real_caller => $self->real_caller,
       );
     }
@@ -63,57 +73,63 @@ package Paws::Net::MockCaller;
   sub send_request {
     my ($self, $service, $call_object) = @_;
 
-    $self->_test_file(sprintf("%s/%04d.response", $self->mock_dir, $self->_request_num));
-    $self->_next_request;
+    if ($self->mock_type eq 'FileMockCaller') {
+      $self->_test_file(sprintf("%s/%04d.response", $self->mock_dir, $self->_request_num));
+      $self->_next_request;
 
-    if ($self->mock_mode eq 'REPLAY') {
-      $self->caller->file($self->_test_file);
-      return $self->caller->send_request($service, $call_object);
-    } elsif ($self->mock_mode eq 'RECORD') {
-      return $self->real_caller->send_request($service, $call_object);
+      if ($self->mock_mode eq 'REPLAY') {
+        $self->caller->file($self->_test_file);
+        return $self->caller->send_request($service, $call_object);
+      } elsif ($self->mock_mode eq 'RECORD') {
+        return $self->real_caller->send_request($service, $call_object);
+      } else {
+        die "Unsupported record mode " . $self->mock_mode;
+      }
     } else {
-      die "Unsupported record mode " . $self->mock_mode;
+      return $self->caller->send_request($service, $call_object);
     }
   };
 
   sub caller_to_response {
     my ($self, $service, $call_object, $response) = @_;
-    my $content = $response->content;
-    my $headers = $response->headers;
- 
-    $content =~ s/<(RequestId)>.*<\/(RequestId)>/<$1>000000000000000000000000000000000000<\/$2>/ if (defined $content);
-    $content =~ s/<(RequestID)>.*<\/(RequestID)>/<$1>000000000000000000000000000000000000<\/$2>/ if (defined $content);
 
-    if ($headers->{ "x-amzn-requestid" }) {
-      $headers->{ "x-amzn-requestid" }  = '000000000000000000000000000000000000' 
-    }
+    if ($self->mock_type eq 'FileMockCaller') {
+      my $content = $response->content;
+      my $headers = $response->headers;
 
-    if ($headers->{ "x-amz-request-id" }) {
-      $headers->{ "x-amz-request-id" }  = '000000000000000000000000000000000000' 
-    }
+      $content =~ s/<(RequestId)>.*<\/(RequestId)>/<$1>000000000000000000000000000000000000<\/$2>/ if (defined $content);
+      $content =~ s/<(RequestID)>.*<\/(RequestID)>/<$1>000000000000000000000000000000000000<\/$2>/ if (defined $content);
 
-    if ($self->mock_mode eq 'RECORD') {
-      my $file = path $self->_test_file;
-      $file->parent->mkpath;
+      if ($headers->{ "x-amzn-requestid" }) {
+        $headers->{ "x-amzn-requestid" }  = '000000000000000000000000000000000000' 
+      }
 
-      write_text($self->_test_file, encode_json({
-        request => {
-          params => $service->to_hash($call_object),
-          service => $service->service,
-          call => $call_object->_api_call,
-        },
-        response => { 
-          content => $response->content, 
-          headers => $response->headers,
-          status  => $response->status,
-        }
-      }));
+      if ($headers->{ "x-amz-request-id" }) {
+        $headers->{ "x-amz-request-id" }  = '000000000000000000000000000000000000' 
+      }
 
-      my $result = $self->real_caller->caller_to_response($service, $call_object, $response);   
+      if ($self->mock_mode eq 'RECORD') {
+        my $file = path $self->_test_file;
+        $file->parent->mkpath;
+
+        write_text($self->_test_file, encode_json({
+          request => {
+            params => $service->to_hash($call_object),
+            service => $service->service,
+            call => $call_object->_api_call,
+          },
+          response => { 
+            content => $response->content, 
+            headers => $response->headers,
+            status  => $response->status,
+          }
+        }));
+      }
+      my $result = $self->caller->caller_to_response($service, $call_object, $response);   
       $self->result_hook->($self, $result) if (defined $self->result_hook);
       return $result;
     } else {
-      return $self->real_caller->caller_to_response($service, $call_object, $response);
+      return $self->caller->caller_to_response($service, $call_object, $response);
     }
   };
 

--- a/lib/Paws/Net/NoResponseMockCaller.pm
+++ b/lib/Paws/Net/NoResponseMockCaller.pm
@@ -1,0 +1,48 @@
+package Paws::Net::NoResponseMockCaller;
+  use Moose;
+
+  with 'Paws::Net::RetryCallerRole', 'Paws::Net::CallerRole';
+
+  use Paws::Net::APIResponse;
+  use File::Slurper qw(read_text write_text);
+  use JSON::MaybeXS;
+  use Moose::Util::TypeConstraints;
+  use Path::Tiny;
+
+  has file => (is => 'rw', isa => 'Str', trigger => \&_set_file);
+
+  has real_caller => (
+    is => 'ro',
+    does => 'Paws::Net::CallerRole',
+    default => sub {
+      require Paws::Net::Caller;
+      Paws::Net::Caller->new;
+    }
+  );
+
+  has actual_request => (
+    is => 'rw',
+    isa => 'Object',
+    lazy => 1,
+    default => sub { '' },
+    );
+
+  has _encoder => (is => 'ro', default => sub { JSON::MaybeXS->new(canonical => 1) });
+
+  sub send_request {
+    my ($self, $service, $call_object) = @_;
+
+    $self->actual_request($service->prepare_request_for_call($call_object));
+    my $actual_call = $self->_encoder->encode($service->to_hash($call_object));
+
+    # we don't care about the response
+    return {};
+  };
+
+  sub caller_to_response {
+    my ($self, $service, $call_object, $response) = @_;
+
+    return $response;
+  };
+
+1;


### PR DESCRIPTION
hey @pplu , in writing more tests for content headers being sent and similar, I couldnt use the existing record/replay to generate test responses, as some of the methods do in fact fail..

As we're only testing the request here, I've redesigned the mocking a bit to allow for no-response tests (else I have to write up a bunch of XXXX.response files by hand..)
