### PR TITLE
Ignore provided 'region' if 'credentialScope' is defined

### DIFF
--- a/lib/Paws/API/EndpointResolver.pm
+++ b/lib/Paws/API/EndpointResolver.pm
@@ -23,12 +23,11 @@ package Paws::API::EndpointResolver;
     default => sub {
       my $self = shift;
       my $sig_region;
-   
-      # For global services:   don't specify region: we sign with the region in the credentialScope
-      #                        specify the region: we override the credentialScope (use the region specified)
+
+      # For global services:   we sign with the region in the credentialScope
       # For regional services: use the region specified for signing
-      # If endpoint is specified: use the region specified (no _endpoint_info) 
-      if (defined $self->_endpoint_info->{ credentialScope } and not defined $self->region) {
+      # If endpoint is specified: use the region specified (no _endpoint_info)
+      if (defined $self->_endpoint_info->{ credentialScope }) {
         $sig_region = $self->_endpoint_info->{ credentialScope }->{ region }
       }
       $sig_region = $self->region if (not defined $sig_region);


### PR DESCRIPTION
If we end in a rule with 'credentialScope', we probably want to ignore
the 'region' even if the user has defined one.

Request to rules with 'credentialScope' are only going to succeed with
the region in it, so if the user (mistakenly or not) has a 'region'
defined the request will fail.

It may be nice, though, to leave a WARNING if 'region' is defined and is
different from the one in 'credentialScope'.