### PR TITLE
fixes content in request being no value

### DIFF
--- a/lib/Paws/Net/APIRequest.pm
+++ b/lib/Paws/Net/APIRequest.pm
@@ -5,7 +5,7 @@ package Paws::Net::APIRequest;
 
   has parameters => (is => 'rw', isa => 'HashRef', default => sub { {} });
   has headers    => (is => 'rw', isa => 'HTTP::Headers', default => sub { HTTP::Headers->new });
-  has content    => (is => 'rw', isa => 'Str|Undef');
+  has content    => (is => 'rw', isa => 'Str|Undef', default => '');
   has method     => (is => 'rw', isa => 'Str');
   has uri        => (is => 'rw', isa => 'Str');
   has url        => (is => 'rw', isa => 'Str');

--- a/t/05_service_calls.t
+++ b/t/05_service_calls.t
@@ -15,7 +15,7 @@ sub request_has_params {
   my ($test_params, $request) = @_;
 
   foreach my $param (keys %$test_params) {
-    cmp_ok($request->parameters->{ $param }, 'eq', $test_params->{ $param }, 
+    cmp_ok($request->parameters->{ $param }, 'eq', $test_params->{ $param },
            "request has a parameter called $param with expected value"
     );
   }
@@ -23,7 +23,7 @@ sub request_has_params {
 
 sub request_contentjson {
   my ($test_params, $request) = @_;
-  
+
   my $content = $request->content;
   my $datastructure = decode_json($content);
 
@@ -82,7 +82,7 @@ $test_params = {
 my $sqs = $aws->service('SQS');
 
 $request = $sqs->CreateQueue(
-  QueueName => 'Paws2AttributeTest', 
+  QueueName => 'Paws2AttributeTest',
   Attributes => {
     DelaySeconds => 10,
     MessageRetentionPeriod => 3600,
@@ -153,7 +153,7 @@ my $ses = $aws->service('SES');
 
 $request = $ses->SendEmail(
   Destination => { ToAddresses => [ 'allan@example.com' ] },
-  Message => { Body => { Text => { Data => 'body' } }, 
+  Message => { Body => { Text => { Data => 'body' } },
                Subject => { Data => 'Example' },
              },
   Source => 'user@example.com',
@@ -188,7 +188,7 @@ request_has_params($test_params, $request);
 
 $request = $ses->GetIdentityNotificationAttributes(
   Identities => [ 'user@example.com' ]
-); 
+);
 
 $test_params = {
   'Identities.member.1' => 'user@example.com',
@@ -228,7 +228,7 @@ $request = $asg->AttachInstances(
 
 $test_params = {
   'AutoScalingGroupName' => 'ASGNAME',
-  'InstanceIds.member.1' => 'i-012345678', 
+  'InstanceIds.member.1' => 'i-012345678',
   'InstanceIds.member.2' => 'i-123456789'
 };
 
@@ -429,7 +429,7 @@ request_contentjson($test_params, $request);
 
 $request = $dynamo->BatchWriteItem(
   RequestItems=>{
-    Table => [ 
+    Table => [
       { PutRequest => {
           Item => {
             pagekey => { S => 'ho' },
@@ -505,8 +505,8 @@ $request = $cf->CreateInvalidation(
         '/object2',
         '/object3'
       ]
-    }   
-  }   
+    }
+  }
 );
 
 my $ref = XMLin($request->content);
@@ -594,6 +594,13 @@ request_contentjson($test_params, $request);
 
 my $r53 = $aws->service('Route53');
 
+$request = $r53->ListResourceRecordSets(
+  HostedZoneId => 'SomeId',
+  MaxItems => '1',
+ );
+
+is($request->content, '', 'content defaults to empty string');
+
 $request = $r53->ListHealthChecks(
   Marker => 'X',
   MaxItems => 50,
@@ -636,7 +643,7 @@ $request = $glacier->InitiateMultipartUpload(
   ArchiveDescription => 'Desc',
   VaultName => 'myvault',
   PartSize => 34
-);  
+);
 
 like($request->url, qr|/myvault/|);
 like($request->url, qr|/1234/|);


### PR DESCRIPTION
Noticed while building tests for requests with Route 53, if you make a GET request that has no "content" as defined by APIRequest.pm (as it is defined 'Str|Undef'), a warning will be thrown by Net::Amazon::Signature::V4 that looks like this:

```
Use of uninitialized value in subroutine entry at *Perl 5 route*/Net/Amazon/Signature/V4.pm** line 106
```

An example pasted can be seen [in this issue](https://github.com/pplu/aws-sdk-perl/issues/167).

The warning code can be seen [here on metacpan](https://metacpan.org/source/DBOOK/Net-Amazon-Signature-V4-0.18/lib/Net/Amazon/Signature/V4.pm#L87). The warning part is `$creq_payload_hash = sha256_hex($req->content)`, where the issue is $req->content doesn't exist, because it is undef. Thus, it warns that is has not been given any value at all.

To give context, as outlined [in the guidelines for signing amazon requests with Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html): 


> When you create the string to sign, you specify the signing algorithm that you used to hash the payload. For example, if you used SHA256, you will specify AWS4-HMAC-SHA256 as the signing algorithm. The hashed payload must be represented as a lowercase hexadecimal string.
> 
> If the payload is empty, use an empty string as the input to the hash function. In the IAM example, the payload is empty.

Where the [python example on v4 signing examples](https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html#sig-v4-examples-get-auth-header) given in the docs does this:

```python
# Step 6: Create payload hash (hash of the request body content). For GET
# requests, the payload is an empty string ("").
payload_hash = hashlib.sha256('').hexdigest()
```

Thus, the solution seems to be to have content default to an empty string if nothing has been given. Implementation should be correct as given.