### PR TITLE
change shebangs for installed scripts to be rewritable on install

### DIFF
--- a/bin/open_aws_console
+++ b/bin/open_aws_console
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use Paws;
 use v5.10;

--- a/bin/paws
+++ b/bin/paws
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use lib 'auto-lib', 'lib';
 

--- a/bin/paws_make_testcase
+++ b/bin/paws_make_testcase
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 my @args = @ARGV;
 


### PR DESCRIPTION
CPAN installers must rewrite the shebang of scripts that are installed to to the perl that installed them. This prevents issues like a shebang of #!/usr/bin/perl being incorrect for scripts installed to a perl installed somewhere else, or a shebang of #!/usr/bin/env perl being incorrect for scripts installed to a perl that isn't the first perl in your path. If a script ends up being run for a different perl than it was installed for, Paws will probably not be installed in that perl so at best it won't work. A shebang of #!perl will be rewritten to the perl being installed to, but a shebang of #!/usr/bin/env perl won't, for historical reasons (https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/58). A shebang of #!/usr/bin/perl will also be rewritten but I prefer to avoid this as people may accidentally run it from a git checkout in a perl they weren't expecting to use. (from a git checkout, just do `perl path/to/script`.)