### PR TITLE
remove dzil deps from cpanfile and provide instructions for dzil installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,14 @@ carton install installs all dependencies in all sections (after all, we're in de
 Packaging
 ============
 
-Packaging is managed with Dist::Zilla. running dzil build will make a tar.gz suitable for uploading to CPAN
+Packaging is managed with Dist::Zilla. To install Dist::Zilla and the necessary plugins, run:
+
+```
+cpanm Dist::Zilla
+dzil authordeps --missing | cpanm
+```
+
+After this, running dzil build will make a tar.gz suitable for uploading to CPAN.
 
 Trying it out
 ============

--- a/cpanfile
+++ b/cpanfile
@@ -33,17 +33,6 @@ on 'develop' => sub {
   requires 'Template';
   requires 'Pod::HTML2Pod';
   requires 'Perl::Tidy';
-  requires 'Dist::Zilla';
-  requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
-  requires 'Dist::Zilla::Plugin::VersionFromMainModule';
-  requires 'Dist::Zilla::PluginBundle::Git';
-  requires 'Dist::Zilla::Plugin::UploadToCPAN';
-  requires 'Dist::Zilla::Plugin::RunExtraTests';
-  requires 'Dist::Zilla::Plugin::Test::Compile';
-  requires 'Dist::Zilla::Plugin::Git::Check';
-  requires 'Dist::Zilla::Plugin::Git::GatherDir';
-  requires 'Dist::Zilla::Plugin::Git::Push';
-  requires 'Dist::Zilla::Plugin::Git::Tag';
   requires 'Carp::Always';
   requires 'Devel::Cover';
   requires 'Data::Printer';


### PR DESCRIPTION
This is just a suggestion. Dist::Zilla deps even in the develop phase tend to clutter up dependency management and analysis, and are unnecessary for most contributors. Thus it's usually best to just document how to use dzil to install the needed deps for its workflow, as dzil can manage this itself based on the dist.ini. I believe you are only using dzil for packaging, not running tests or anything, so it should not affect any of the rest of the development setup (and should significantly lessen the amount of time to install development deps for those who don't need it).