### PR TITLE
Make 'Paws' dependency explicit on Paws::API::Caller

### DIFF
--- a/lib/Paws/API/Caller.pm
+++ b/lib/Paws/API/Caller.pm
@@ -1,6 +1,7 @@
 package Paws::API::Caller;
   use Moose::Role;
   use Carp;
+  use Paws;
   use Paws::Net::APIRequest;
   use Paws::API::Response;
 


### PR DESCRIPTION
This class uses Paws->load_class internally but does not declare it with
a 'use'. Most of the time it's ok because you already have Paws loaded,
but if you try to load Paws::API::Caller alone and call one of it's
methods, it will fail.

Adding this 'use Paws' prevents this eventual problem, and also makes a
bit clearer what depends on what on the Paws ecosystem.