### PR TITLE
Fix Uninitialized Value warnings

### DIFF
--- a/lib/Paws/Net/RestXmlCaller.pm
+++ b/lib/Paws/Net/RestXmlCaller.pm
@@ -105,7 +105,7 @@ package Paws::Net::RestXmlCaller;
              $value = $attribute->get_value($call);
           }
           else {
-            $value = MIME::Base64::encode_base64( Digest::MD5::md5( $request->content ) );
+            $value = MIME::Base64::encode_base64( Digest::MD5::md5( $request->content || '' ) );
             chomp $value;
           }
           $request->headers->header( $attribute->header_name => $value );

--- a/lib/Paws/Net/RestXmlCaller.pm
+++ b/lib/Paws/Net/RestXmlCaller.pm
@@ -105,7 +105,7 @@ package Paws::Net::RestXmlCaller;
              $value = $attribute->get_value($call);
           }
           else {
-            $value = MIME::Base64::encode_base64( Digest::MD5::md5( $request->content || '' ) );
+            $value = MIME::Base64::encode_base64( Digest::MD5::md5( $request->content // '' ) );
             chomp $value;
           }
           $request->headers->header( $attribute->header_name => $value );


### PR DESCRIPTION
Encountered warnings during 
```
  $s3->PutObjectACL( 
    Bucket =>, 
    Key =>, 
    ACL => 'bucket-owner-full-control');
```
This gets rid of the warnings and `PutObjectACL` still works