### PR TITLE
Revert "Make 'Paws' dependency explicit on Paws::API::Caller"

### DIFF
--- a/lib/Paws/API/Caller.pm
+++ b/lib/Paws/API/Caller.pm
@@ -1,7 +1,6 @@
 package Paws::API::Caller;
   use Moose::Role;
   use Carp;
-  use Paws;
   use Paws::Net::APIRequest;
   use Paws::API::Response;
 


### PR DESCRIPTION
Reverts pplu/aws-sdk-perl#280