### PR TITLE
Fix/issue 212

### DIFF
--- a/lib/Paws/Net/RestJsonCaller.pm
+++ b/lib/Paws/Net/RestJsonCaller.pm
@@ -113,15 +113,25 @@ package Paws::Net::RestJsonCaller;
 
     $self->_to_header_params($request, $call);
     
-    if ($call->can('_stream_param')) {
-      my $param_name = $call->_stream_param;
-      $request->content($call->$param_name);
-      #$request->headers->header( 'content-length' => $request->content_length );
-      #$request->headers->header( 'content-type'   => $self->content_type );
+   #bug 212 JSP 10/18/2018
+   #I use the '_stream_content' here to set the content to ""
+   # for Pinpoint calls
+    if ($call->can('_stream_param') and not $call->can('_stream_content') ){
+          my $param_name = $call->_stream_param;
+         $request->content($call->$param_name);
+
     } else {
+
       my $data = $self->_to_jsoncaller_params($call);
-      $request->content(encode_json($data));
+      if ($call->can('_stream_content') and keys(%{$data}) ==0){
+          $data = "";
+      }
+      else {
+           $data = encode_json($data);
+      }
+      $request->content($data);
     }
+
     
     $request->method($call->_api_method);
 

--- a/lib/Paws/Net/RestJsonCaller.pm
+++ b/lib/Paws/Net/RestJsonCaller.pm
@@ -4,7 +4,7 @@ package Paws::Net::RestJsonCaller;
   use POSIX qw(strftime); 
   use URI::Template;
   use JSON::MaybeXS;
-
+  use Scalar::Util; 
   use Paws::Net::RestJsonResponse;
 
   has response_to_object => (
@@ -112,16 +112,13 @@ package Paws::Net::RestJsonCaller;
     $request->url($url);
 
     $self->_to_header_params($request, $call);
-use Data::Dumper;
     
     if ($call->can('_stream_param')) {
       my $param_name = $call->_stream_param;
       
-warn("JSP param_name=".Scalar::Util::blessed($call->$param_name));
       if (Scalar::Util::blessed($call->$param_name)){
           my $attribute = $call->$param_name;
           my $content = encode_json({%$attribute});
-          warn("JSP here content=".Dumper($content));
           $request->content($content);
           $request->headers->header('Content-Type'=>'application/json');
           $request->headers->header('Content-Length'=>length($content));
@@ -133,8 +130,6 @@ warn("JSP param_name=".Scalar::Util::blessed($call->$param_name));
       #$request->headers->header( 'content-type'   => $self->content_type );
     } else {
       my $data = $self->_to_jsoncaller_params($call);
-use Data::Dumper;
-warn("data=".Dumper($data));      
       if (keys(%{$data})){
         $request->content(encode_json($data));
       }

--- a/lib/Paws/Net/RestJsonResponse.pm
+++ b/lib/Paws/Net/RestJsonResponse.pm
@@ -6,7 +6,6 @@ package Paws::Net::RestJsonResponse;
 
   sub process {
     my ($self, $call_object, $response) = @_;
-
     if ($response->has_header('x-amz-crc32')) {
       require String::CRC32;
       my $crc = String::CRC32::crc32($response->content);

--- a/lib/Paws/Net/RestJsonResponse.pm
+++ b/lib/Paws/Net/RestJsonResponse.pm
@@ -209,25 +209,18 @@ package Paws::Net::RestJsonResponse;
                      || $response->header('x-amzn-requestid');
       
     if ($returns){
-      return $self->new_from_response($call_object, $response, $request_id);
+      return $self->new_from_response($call_object->_returns, $response, $request_id);
     } else {
       return Paws::API::Response->new(
         _request_id => $request_id,
       );
     }
   }
-  #bug 212 JPS 10/18/2018
-  #changed the signature on the so I can use the
-  #'_stream_content' from the call_object to get the correct
-  #'_stream_param' for the %args
 
   sub new_from_response {
-    my ($self, $call_object, $response, $request_id) = @_;
-    
-    my $class = $call_object->_returns;
-    
-    if (not $class->can('_stream_param') and not $call_object->can("_stream_content")) {
+    my ($self, $class, $response, $request_id) = @_;
 
+    if (not $class->can('_stream_param')) {
       # Object is serialized in the body of the response
       my $unserialized_struct = $self->unserialize_response( $response );
       
@@ -245,16 +238,7 @@ package Paws::Net::RestJsonResponse;
         }
       }
 
-      if ($call_object->can("_stream_content")){
-
-        my $unserialized_struct = $self->unserialize_response( $response );
-        $args{ $call_object->_stream_param } =  $unserialized_struct;
-        return $self->new_from_result_struct($class, \%args);
-      }
-      else {
-        $args{ $class->_stream_param } = $response->content;
-        return $class->new(%args)
-      }
+      $args{ $class->_stream_param } = $response->content;
 
       return $class->new(%args);
     }

--- a/lib/Paws/Net/RestJsonResponse.pm
+++ b/lib/Paws/Net/RestJsonResponse.pm
@@ -209,18 +209,25 @@ package Paws::Net::RestJsonResponse;
                      || $response->header('x-amzn-requestid');
       
     if ($returns){
-      return $self->new_from_response($call_object->_returns, $response, $request_id);
+      return $self->new_from_response($call_object, $response, $request_id);
     } else {
       return Paws::API::Response->new(
         _request_id => $request_id,
       );
     }
   }
+  #bug 212 JPS 10/18/2018
+  #changed the signature on the so I can use the
+  #'_stream_content' from the call_object to get the correct
+  #'_stream_param' for the %args
 
   sub new_from_response {
-    my ($self, $class, $response, $request_id) = @_;
+    my ($self, $call_object, $response, $request_id) = @_;
+    
+    my $class = $call_object->_returns;
+    
+    if (not $class->can('_stream_param') and not $call_object->can("_stream_content")) {
 
-    if (not $class->can('_stream_param')) {
       # Object is serialized in the body of the response
       my $unserialized_struct = $self->unserialize_response( $response );
       
@@ -238,7 +245,16 @@ package Paws::Net::RestJsonResponse;
         }
       }
 
-      $args{ $class->_stream_param } = $response->content;
+      if ($call_object->can("_stream_content")){
+
+        my $unserialized_struct = $self->unserialize_response( $response );
+        $args{ $call_object->_stream_param } =  $unserialized_struct;
+        return $self->new_from_result_struct($class, \%args);
+      }
+      else {
+        $args{ $class->_stream_param } = $response->content;
+        return $class->new(%args)
+      }
 
       return $class->new(%args);
     }

--- a/templates/restjson/callargs_class.tt
+++ b/templates/restjson/callargs_class.tt
@@ -23,6 +23,11 @@ package [% c.api %]::[% operation.name %];
     [%- IF (operation.output.keys.size) -%]
       [%- c.api %]::[% c.shapename_for_operation_output(op_name) -%]
     [%- ELSE -%]Paws::API::Response[% END -%]');
+
+  [%- IF (operation.http.stream_content) -%]
+  class_has _stream_content => (isa => 'Boolean', is => 'ro', default=>1);
+  [% END %]
+
 1;
 
 [% INCLUDE 'callclass_documentation.tt' %]


### PR DESCRIPTION
Ok all fixed up
in the end a few changes to RestJsonCaller.pm to account for
   

1. Empty content can not be '{}' on pinpoint
2. check the '$call->_stream_param' attribute to see it it an object and if it is
   2. 1.     encode the object
   2. 2.     set the content to the encoded object
   2. 3.     set the 'Content-Type header to 'application/json'
   2. 4.     set the 'Content-length' header to the length of the encoded object

Also changes to boto to big to list here