### PR TITLE
Add common utils to paws

### DIFF
--- a/auto-lib/Paws.pm
+++ b/auto-lib/Paws.pm
@@ -59,6 +59,8 @@ package Paws;
 
 our $VERSION = '0.38';
 
+use Carp;
+
 use Moose;
 use MooseX::ClassAttribute;
 use Moose::Util qw//;
@@ -92,6 +94,89 @@ sub load_class {
     # immutability is a global setting that will affect all instances
     $class->meta->make_immutable if (Paws->default_config->immutable);
   }
+}
+
+# converts the params the user passed to the call into objects that represent the call
+sub new_with_coercions {
+  my (undef, $class, %params) = @_;
+
+  Paws->load_class($class);
+  my %p;
+
+  if ($class->does('Paws::API::StrToObjMapParser')) {
+    my ($subtype) = ($class->meta->find_attribute_by_name('Map')->type_constraint =~ m/^HashRef\[(.*?)\]$/);
+    if (my ($array_of) = ($subtype =~ m/^ArrayRef\[(.*?)\]$/)){
+      $p{ Map } = { map { $_ => [ map { Paws->new_with_coercions("$array_of", %$_) } @{ $params{ $_ } } ] } keys %params };
+    } else {
+      $p{ Map } = { map { $_ => Paws->new_with_coercions("$subtype", %{ $params{ $_ } }) } keys %params };
+    }
+  } elsif ($class->does('Paws::API::StrToNativeMapParser')) {
+    $p{ Map } = { %params };
+  } else {
+    foreach my $att (keys %params){
+      my $att_meta = $class->meta->find_attribute_by_name($att);
+
+      croak "$class doesn't have an $att" if (not defined $att_meta);
+      my $type = $att_meta->type_constraint;
+
+      if ($type eq 'Bool') {
+        $p{ $att } = ($params{ $att } == 1)?1:0;
+      } elsif ($type eq 'Str' or $type eq 'Num' or $type eq 'Int') {
+        $p{ $att } = $params{ $att };
+      } elsif ($type =~ m/^ArrayRef\[(.*?)\]$/){
+        my $subtype = "$1";
+        if ($subtype eq 'Str' or $subtype eq 'Str|Undef' or $subtype eq 'Num' or $subtype eq 'Int' or $subtype eq 'Bool') {
+          $p{ $att } = $params{ $att };
+        } else {
+          $p{ $att } = [ map { Paws->new_with_coercions("$subtype", %{ $_ }) } @{ $params{ $att } } ];
+        }
+      } elsif ($type->isa('Moose::Meta::TypeConstraint::Enum')){
+        $p{ $att } = $params{ $att };
+      } else {
+        $p{ $att } = Paws->new_with_coercions("$type", %{ $params{ $att } });
+      }
+    }
+  }
+  return $class->new(%p);
+}
+
+sub is_internal_type {
+  my (undef, $att_type) = @_;
+  return ($att_type eq 'Str' or $att_type eq 'Str|Undef' or $att_type eq 'Int' or $att_type eq 'Bool' or $att_type eq 'Num');
+}
+
+sub to_hash {
+  my (undef, $params) = @_;
+  my $refHash = {};
+
+  if      ($params->does('Paws::API::StrToNativeMapParser')) {
+    return $params->Map;
+  } elsif ($params->does('Paws::API::StrToObjMapParser')) {
+    return { map { ($_ => Paws->to_hash($params->Map->{$_})) } keys %{ $params->Map } };
+  }
+
+  foreach my $att (grep { $_ !~ m/^_/ } $params->meta->get_attribute_list) {
+    my $key = $att;
+    if (defined $params->$att) {
+      my $att_type = $params->meta->get_attribute($att)->type_constraint;
+      if ($att_type eq 'Bool') {
+        $refHash->{ $key } = ($params->$att)?1:0;
+      } elsif (Paws->is_internal_type($att_type)) {
+        $refHash->{ $key } = $params->$att;
+      } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
+        if (Paws->is_internal_type("$1")){
+          $refHash->{ $key } = $params->$att;
+        } else {
+          $refHash->{ $key } = [ map { Paws->to_hash($_) } @{ $params->$att } ];
+        }
+      } elsif ($att_type->isa('Moose::Meta::TypeConstraint::Enum')) {
+        $refHash->{ $key } = $params->$att;
+      } else {
+        $refHash->{ $key } = Paws->to_hash($params->$att);
+      }
+    }
+  }
+  return $refHash;
 }
 
 sub available_services {

--- a/lib/Paws/API/Caller.pm
+++ b/lib/Paws/API/Caller.pm
@@ -1,6 +1,6 @@
 package Paws::API::Caller;
   use Moose::Role;
-  use Carp;
+  use Paws;
   use Paws::Net::APIRequest;
   use Paws::API::Response;
 
@@ -17,83 +17,13 @@ package Paws::API::Caller;
   sub new_with_coercions {
     my ($self, $class, %params) = @_;
 
-    Paws->load_class($class);
-    my %p;
-
-    if ($class->does('Paws::API::StrToObjMapParser')) {
-      my ($subtype) = ($class->meta->find_attribute_by_name('Map')->type_constraint =~ m/^HashRef\[(.*?)\]$/);
-      if (my ($array_of) = ($subtype =~ m/^ArrayRef\[(.*?)\]$/)){
-        $p{ Map } = { map { $_ => [ map { $self->new_with_coercions("$array_of", %$_) } @{ $params{ $_ } } ] } keys %params };
-      } else {
-        $p{ Map } = { map { $_ => $self->new_with_coercions("$subtype", %{ $params{ $_ } }) } keys %params };
-      }
-    } elsif ($class->does('Paws::API::StrToNativeMapParser')) {
-      $p{ Map } = { %params };
-    } else {
-      foreach my $att (keys %params){
-        my $att_meta = $class->meta->find_attribute_by_name($att);
-  
-        croak "$class doesn't have an $att" if (not defined $att_meta);
-        my $type = $att_meta->type_constraint;
-  
-        if ($type eq 'Bool') {
-          $p{ $att } = ($params{ $att } == 1)?1:0;
-        } elsif ($type eq 'Str' or $type eq 'Num' or $type eq 'Int') {
-          $p{ $att } = $params{ $att };
-        } elsif ($type =~ m/^ArrayRef\[(.*?)\]$/){
-          my $subtype = "$1";
-          if ($subtype eq 'Str' or $subtype eq 'Str|Undef' or $subtype eq 'Num' or $subtype eq 'Int' or $subtype eq 'Bool') {
-            $p{ $att } = $params{ $att };
-          } else {
-            $p{ $att } = [ map { $self->new_with_coercions("$subtype", %{ $_ }) } @{ $params{ $att } } ];
-          }
-        } elsif ($type->isa('Moose::Meta::TypeConstraint::Enum')){
-          $p{ $att } = $params{ $att };
-        } else {
-          $p{ $att } = $self->new_with_coercions("$type", %{ $params{ $att } });
-        }
-      }
-    }
-    return $class->new(%p);
-  }
-
-  sub _is_internal_type {
-    my ($self, $att_type) = @_;
-    return ($att_type eq 'Str' or $att_type eq 'Str|Undef' or $att_type eq 'Int' or $att_type eq 'Bool' or $att_type eq 'Num');
+    Paws->new_with_coercions($class, %params);
   }
 
   sub to_hash {
     my ($self, $params) = @_;
-    my $refHash = {};
 
-    if      ($params->does('Paws::API::StrToNativeMapParser')) {
-      return $params->Map;
-    } elsif ($params->does('Paws::API::StrToObjMapParser')) {
-      return { map { ($_ => $self->to_hash($params->Map->{$_})) } keys %{ $params->Map } };
-    }
-
-    foreach my $att (grep { $_ !~ m/^_/ } $params->meta->get_attribute_list) {
-      my $key = $att;
-      if (defined $params->$att) {
-        my $att_type = $params->meta->get_attribute($att)->type_constraint;
-        if ($att_type eq 'Bool') {
-          $refHash->{ $key } = ($params->$att)?1:0;
-        } elsif ($self->_is_internal_type($att_type)) {
-          $refHash->{ $key } = $params->$att;
-        } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if ($self->_is_internal_type("$1")){
-            $refHash->{ $key } = $params->$att;
-          } else {
-            $refHash->{ $key } = [ map { $self->to_hash($_) } @{ $params->$att } ];
-          }
-        } elsif ($att_type->isa('Moose::Meta::TypeConstraint::Enum')) {
-          $refHash->{ $key } = $params->$att;
-        } else {
-          $refHash->{ $key } = $self->to_hash($params->$att);
-        }
-      }
-    }
-    return $refHash;
+    return Paws->to_hash($params);
   }
 
   sub response_to_object {

--- a/lib/Paws/Net/EC2Caller.pm
+++ b/lib/Paws/Net/EC2Caller.pm
@@ -1,4 +1,5 @@
 package Paws::Net::EC2Caller;
+  use Paws;
   use Moose::Role;
   use HTTP::Request::Common;
   use POSIX qw(strftime); 
@@ -35,14 +36,14 @@ package Paws::Net::EC2Caller;
       if (defined $params->$att) {
         my $att_type = $params->meta->get_attribute($att)->type_constraint;
 
-        if ($self->_is_internal_type($att_type)) {
+        if (Paws->is_internal_type($att_type)) {
           if ($att_type eq 'Bool') {
             $p{ $key } = ($params->{$att} == 1) ? 'true' : 'false';
           } else {
             $p{ $key } = $params->{$att};
           }
         } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if ($self->_is_internal_type("$1")){
+          if (Paws->is_internal_type("$1")){
             my $i = 1;
             foreach my $value (@{ $params->$att }){
               $p{ sprintf($self->array_flatten_string, $key, $i) } = $value;

--- a/lib/Paws/Net/JsonCaller.pm
+++ b/lib/Paws/Net/JsonCaller.pm
@@ -1,4 +1,5 @@
 package Paws::Net::JsonCaller;
+  use Paws;
   use Moose::Role;
   use JSON::MaybeXS;
   use POSIX qw(strftime);
@@ -39,10 +40,10 @@ package Paws::Net::JsonCaller;
           } elsif ($att_type eq 'Str') {
             # concatenate an empty string so numbers get transmitted as strings
             $p{ $key } = "" . $params->$att;
-          } elsif ($self->_is_internal_type($att_type)) {
+          } elsif (Paws->is_internal_type($att_type)) {
             $p{ $key } = $params->$att;
           } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-            if ($self->_is_internal_type("$1")){
+            if (Paws->is_internal_type("$1")){
               $p{ $key } = $params->$att;
             } else {
               $p{ $key } = [ map { $self->_to_jsoncaller_params($_) } @{ $params->$att } ];

--- a/lib/Paws/Net/QueryCaller.pm
+++ b/lib/Paws/Net/QueryCaller.pm
@@ -1,4 +1,5 @@
 package Paws::Net::QueryCaller;
+  use Paws;
   use Moose::Role;
   use HTTP::Request::Common;
   use POSIX qw(strftime); 
@@ -26,14 +27,14 @@ package Paws::Net::QueryCaller;
       if (defined $params->$att) {
         my $att_type = $params->meta->get_attribute($att)->type_constraint;
 
-        if ($self->_is_internal_type($att_type)) {
+        if (Paws->is_internal_type($att_type)) {
           if ($att_type eq 'Bool') {
             $p{ $key } = ($params->{$att} == 1) ? 'true' : 'false';
           } else {
             $p{ $key } = $params->{$att};
           }
         } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if ($self->_is_internal_type("$1")){
+          if (Paws->is_internal_type("$1")){
             my $i = 1;
             foreach my $value (@{ $params->$att }){
               $p{ sprintf($self->array_flatten_string, $key, $i) } = $value;

--- a/lib/Paws/Net/RestJsonCaller.pm
+++ b/lib/Paws/Net/RestJsonCaller.pm
@@ -1,4 +1,5 @@
 package Paws::Net::RestJsonCaller;
+  use Paws;
   use Moose::Role;
   use HTTP::Request::Common;
   use POSIX qw(strftime); 
@@ -37,10 +38,10 @@ package Paws::Net::RestJsonCaller;
         } elsif ($att_type eq 'Str') {
           # concatenate an empty string so numbers get transmitted as strings
           $p{ $key } = "" . $params->$att;
-        } elsif ($self->_is_internal_type($att_type)) {
+        } elsif (Paws->is_internal_type($att_type)) {
           $p{ $key } = $params->$att;
         } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if ($self->_is_internal_type("$1")){
+          if (Paws->is_internal_type("$1")){
             $p{ $key } = $params->$att;
           } else {
             $p{ $key } = [ map { $self->_to_jsoncaller_params($_) } @{ $params->$att } ];

--- a/lib/Paws/Net/RestXmlCaller.pm
+++ b/lib/Paws/Net/RestXmlCaller.pm
@@ -1,4 +1,5 @@
 package Paws::Net::RestXmlCaller;
+  use Paws;
   use Moose::Role;
   use HTTP::Request::Common;
   use POSIX qw(strftime);
@@ -36,10 +37,10 @@ package Paws::Net::RestXmlCaller;
       if (defined $params->$att) {
         my $att_type = $params->meta->get_attribute($att)->type_constraint;
 
-        if ($self->_is_internal_type($att_type)) {
+        if (Paws->is_internal_type($att_type)) {
           $p{ $key } = $params->{$att};
         } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if ($self->_is_internal_type("$1")){
+          if (Paws->is_internal_type("$1")){
             my $i = 1;
             foreach my $value (@{ $params->$att }){
               $p{ sprintf($self->array_flatten_string, $key, $i) } = $value;

--- a/t/lib/TestMakerCaller.pm
+++ b/t/lib/TestMakerCaller.pm
@@ -11,7 +11,7 @@ package TestMakerCaller;
 
       my $test = { tests => [] };
 
-      my $h = Paws::API::Caller->to_hash($result);
+      my $h = Paws->to_hash($result);
       $h = Hash::Flatten::flatten($h, { HashDelimiter => '.', ArrayDelimiter => '.' });
       $test->{ tests } = [ map { { expected => $h->{ $_ }, op => 'eq', path => $_ } } keys %$h ];
 

--- a/templates/paws.tt
+++ b/templates/paws.tt
@@ -60,6 +60,8 @@ package Paws;
 
 our $VERSION = '[% c.version %]';
 
+use Carp;
+
 use Moose;
 use MooseX::ClassAttribute;
 use Moose::Util qw//;
@@ -93,6 +95,89 @@ sub load_class {
     # immutability is a global setting that will affect all instances
     $class->meta->make_immutable if (Paws->default_config->immutable);
   }
+}
+
+# converts the params the user passed to the call into objects that represent the call
+sub new_with_coercions {
+  my (undef, $class, %params) = @_;
+
+  Paws->load_class($class);
+  my %p;
+
+  if ($class->does('Paws::API::StrToObjMapParser')) {
+    my ($subtype) = ($class->meta->find_attribute_by_name('Map')->type_constraint =~ m/^HashRef\[(.*?)\]$/);
+    if (my ($array_of) = ($subtype =~ m/^ArrayRef\[(.*?)\]$/)){
+      $p{ Map } = { map { $_ => [ map { Paws->new_with_coercions("$array_of", %$_) } @{ $params{ $_ } } ] } keys %params };
+    } else {
+      $p{ Map } = { map { $_ => Paws->new_with_coercions("$subtype", %{ $params{ $_ } }) } keys %params };
+    }
+  } elsif ($class->does('Paws::API::StrToNativeMapParser')) {
+    $p{ Map } = { %params };
+  } else {
+    foreach my $att (keys %params){
+      my $att_meta = $class->meta->find_attribute_by_name($att);
+
+      croak "$class doesn't have an $att" if (not defined $att_meta);
+      my $type = $att_meta->type_constraint;
+
+      if ($type eq 'Bool') {
+        $p{ $att } = ($params{ $att } == 1)?1:0;
+      } elsif ($type eq 'Str' or $type eq 'Num' or $type eq 'Int') {
+        $p{ $att } = $params{ $att };
+      } elsif ($type =~ m/^ArrayRef\[(.*?)\]$/){
+        my $subtype = "$1";
+        if ($subtype eq 'Str' or $subtype eq 'Str|Undef' or $subtype eq 'Num' or $subtype eq 'Int' or $subtype eq 'Bool') {
+          $p{ $att } = $params{ $att };
+        } else {
+          $p{ $att } = [ map { Paws->new_with_coercions("$subtype", %{ $_ }) } @{ $params{ $att } } ];
+        }
+      } elsif ($type->isa('Moose::Meta::TypeConstraint::Enum')){
+        $p{ $att } = $params{ $att };
+      } else {
+        $p{ $att } = Paws->new_with_coercions("$type", %{ $params{ $att } });
+      }
+    }
+  }
+  return $class->new(%p);
+}
+
+sub is_internal_type {
+  my (undef, $att_type) = @_;
+  return ($att_type eq 'Str' or $att_type eq 'Str|Undef' or $att_type eq 'Int' or $att_type eq 'Bool' or $att_type eq 'Num');
+}
+
+sub to_hash {
+  my (undef, $params) = @_;
+  my $refHash = {};
+
+  if      ($params->does('Paws::API::StrToNativeMapParser')) {
+    return $params->Map;
+  } elsif ($params->does('Paws::API::StrToObjMapParser')) {
+    return { map { ($_ => Paws->to_hash($params->Map->{$_})) } keys %{ $params->Map } };
+  }
+
+  foreach my $att (grep { $_ !~ m/^_/ } $params->meta->get_attribute_list) {
+    my $key = $att;
+    if (defined $params->$att) {
+      my $att_type = $params->meta->get_attribute($att)->type_constraint;
+      if ($att_type eq 'Bool') {
+        $refHash->{ $key } = ($params->$att)?1:0;
+      } elsif (Paws->is_internal_type($att_type)) {
+        $refHash->{ $key } = $params->$att;
+      } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
+        if (Paws->is_internal_type("$1")){
+          $refHash->{ $key } = $params->$att;
+        } else {
+          $refHash->{ $key } = [ map { Paws->to_hash($_) } @{ $params->$att } ];
+        }
+      } elsif ($att_type->isa('Moose::Meta::TypeConstraint::Enum')) {
+        $refHash->{ $key } = $params->$att;
+      } else {
+        $refHash->{ $key } = Paws->to_hash($params->$att);
+      }
+    }
+  }
+  return $refHash;
 }
 
 sub available_services {


### PR DESCRIPTION
All three `new_with_coercions` and `to_hash` and `is_internal_type` are called in multiple places both in Paws code and for clients using Paws.         
                                                                                
Having them in Paws::API::Caller it's a bit awkward for me, because I don't associate these utilities to the caller (which, as far as I understand, is designed to allow caller pluggability).                          
                                                                                
I've considered creating a Paws::Util or something like that, but it looked to me that `load_class`, that was already under Paws.pm, was the same kind of utility, and therefore I've put the three of them together. 