### PR TITLE
Move `prove` arguments to .proverc

### DIFF
--- a/.proverc
+++ b/.proverc
@@ -1,0 +1,1 @@
+-v -Ilib -Iauto-lib

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	carton exec -- prove -v -I lib -I auto-lib t/
+	carton exec -- prove t/
 
 pod-test:
 	for i in `find auto-lib/Paws/ -name \*.pm`; do podchecker $$i; done;


### PR DESCRIPTION
This makes it easier to run only selected tests by

    $ carton exec -- prove t/foo.t