### PR TITLE
bin/paws should not add lib to @INC

### DIFF
--- a/bin/paws
+++ b/bin/paws
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-use lib 'auto-lib', 'lib';
-
 use 5.010;
 use strict;
 use warnings;

--- a/bin/paws_make_testcase
+++ b/bin/paws_make_testcase
@@ -5,6 +5,6 @@ my @args = @ARGV;
 $ENV{PAWS_MOCK_MODE} = 'RECORD';
 $ENV{PAWS_MOCK_DIR} = 'tests/' . time . '/';
 
-my @cmd = ('perl', '-I', 't/lib', 'bin/paws', $args[0], '--caller', 'TestMakerCaller', @args[1..$#args]);
+my @cmd = ('perl', '-I', 't/lib', '-I', 'lib', 'bin/paws', $args[0], '--caller', 'TestMakerCaller', @args[1..$#args]);
 
 system @cmd;


### PR DESCRIPTION
bin/paws binary seem to be designed for end
users and should not add an unsafe directory
to @INC. As we cannot predict where will be
the 'auto-lib' and 'lib' directories.

bin/paws_make_testcase is a tool for the distribution
and should not be shipped (view #309), we can add lib
to it to preserve its current behavior.