### PR TITLE
Fix/issue 324

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 0.40
+ - Solve issue #324. Paws won't die when any API returns duplicate requestid headers. IAM has 
+   started returning duplicate request id headers, basically rendering old versions of Paws
+   unable to call IAM. Issue #324 has instructions for users of older versions of Paws.
 
 0.39 11 Feb 2019
  - Paws is now installed with Module::Builder::Tiny, which speeds

--- a/lib/Paws/Net/JsonResponse.pm
+++ b/lib/Paws/Net/JsonResponse.pm
@@ -224,6 +224,8 @@ package Paws::Net::JsonResponse;
 
     my $headers = $response->headers;
     my $request_id = $headers->{'x-amz-request-id'} || $headers->{'x-amzn-requestid'};
+    # AWS has sent duplicate headers x-amx-request-id headers on some services. See issue 324 for more info
+    $request_id = (ref($request_id) eq 'ARRAY') ? $request_id->[0] : $request_id;
  
     return Paws::API::Response->new(_request_id => $request_id) if (not $returns);
 

--- a/lib/Paws/Net/XMLResponse.pm
+++ b/lib/Paws/Net/XMLResponse.pm
@@ -306,6 +306,9 @@ package Paws::Net::XMLResponse;
                       || $unserialized_struct->{'RequestId'} 
                       || $unserialized_struct->{'RequestID'}
                       || $unserialized_struct->{ ResponseMetadata }->{ RequestId };
+
+    # AWS has sent duplicate headers x-amx-request-id headers on some services. See issue 324 for more info
+    $request_id = (ref($request_id) eq 'ARRAY') ? $request_id->[0] : $request_id;
       
     if ($returns){
       if ($call_object->_result_key){

--- a/t/20_json_syntetic_responses.t
+++ b/t/20_json_syntetic_responses.t
@@ -24,6 +24,11 @@ my $s = $aws->service('JsonParamsService',
 }
 
 { 
+  my $r = $s->Method1(response => '{}', dup_requestid => 1);
+  isa_ok($r, 'Paws::JsonParamsService::Method1Return');
+}
+
+{ 
   my $r = $s->Method1(response => '{"StringAttribute":"String","IntegerAttribute":42,"BooleanAttribute":true}');
   isa_ok($r, 'Paws::JsonParamsService::Method1Return');
   cmp_ok($r->StringAttribute, 'eq', 'String');

--- a/t/21_restjson_syntetic_responses.t
+++ b/t/21_restjson_syntetic_responses.t
@@ -24,6 +24,11 @@ my $s = $aws->service('JsonParamsService',
 }
 
 { 
+  my $r = $s->Method1(response => '{}', dup_requestid => 1);
+  isa_ok($r, 'Paws::JsonParamsService::Method1Return');
+}
+
+{ 
   my $r = $s->Method1(response => '{"StringAttribute":"String","IntegerAttribute":42,"BooleanAttribute":true}');
   isa_ok($r, 'Paws::JsonParamsService::Method1Return');
   cmp_ok($r->StringAttribute, 'eq', 'String');

--- a/t/22_query_syntetic_responses.t
+++ b/t/22_query_syntetic_responses.t
@@ -31,6 +31,20 @@ my $s = $aws->service('QueryParamsService',
   isa_ok($r, 'Paws::JsonParamsService::Method1Return');
 }
 
+{
+  note "Response with duplicate headers";
+  my $r = $s->Method2(response => q'
+  <Method2Response xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+    <Method2Result>
+    </Method2Result>
+    <ResponseMetadata>
+      <RequestId>384ac68d-3775-11df-8963-01868b7c937a</RequestId>
+    </ResponseMetadata>
+  </Method2Response>
+', dup_requestid => 1);
+  isa_ok($r, 'Paws::JsonParamsService::Method1Return');
+}
+
 { 
   my $r = $s->Method2(response => q'
   <Method2Response xmlns="http://sns.amazonaws.com/doc/2010-03-31/">

--- a/t/23_queryflatten_syntetic_responses.t
+++ b/t/23_queryflatten_syntetic_responses.t
@@ -35,6 +35,19 @@ my $s = $aws->service('QueryFlattenedParamsService',
   my $r = $s->Method2(response => q'
   <Method2Response xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
     <Method2Result>
+    </Method2Result>
+    <ResponseMetadata>
+      <RequestId>384ac68d-3775-11df-8963-01868b7c937a</RequestId>
+    </ResponseMetadata>
+  </Method2Response>
+', dup_requestid => 1);
+  isa_ok($r, 'Paws::JsonParamsService::Method1Return');
+}
+
+{ 
+  my $r = $s->Method2(response => q'
+  <Method2Response xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+    <Method2Result>
       <StringAttribute>String</StringAttribute>
       <IntegerAttribute>42</IntegerAttribute>
       <BooleanAttribute>1</BooleanAttribute>

--- a/t/lib/Paws/JsonParamsService/Method1.pm
+++ b/t/lib/Paws/JsonParamsService/Method1.pm
@@ -5,6 +5,7 @@ package Paws::JsonParamsService::Method1;
 
   has response => (isa => 'Str', is => 'ro', required => 1);
   has status => (isa => 'Int', is => 'ro', default => 200);
+  has dup_requestid => (isa => 'Bool', is => 'ro', default => 0);
 
   use MooseX::ClassAttribute;
 

--- a/t/lib/Paws/JsonParamsService/Method1Return.pm
+++ b/t/lib/Paws/JsonParamsService/Method1Return.pm
@@ -18,4 +18,6 @@ package Paws::JsonParamsService::Method1Return;
 
   has MapOfArrayOfString => (is => 'ro', isa => 'Paws::JsonParamsService::MapOfArrayOfString');
   has MapOfArrayOfObject => (is => 'ro', isa => 'Paws::JsonParamsService::MapOfArrayOfObject');
+
+  has _request_id => (is => 'ro', isa => 'Str');
 1;

--- a/t/lib/Paws/JsonParamsService/Method2.pm
+++ b/t/lib/Paws/JsonParamsService/Method2.pm
@@ -5,6 +5,7 @@ package Paws::JsonParamsService::Method2;
 
   has response => (isa => 'Str', is => 'ro', required => 1);
   has status => (isa => 'Int', is => 'ro', default => 200);
+  has dup_requestid => (isa => 'Bool', is => 'ro', default => 0);
 
   use MooseX::ClassAttribute;
 

--- a/t/lib/Paws/JsonParamsService/Method3.pm
+++ b/t/lib/Paws/JsonParamsService/Method3.pm
@@ -3,6 +3,7 @@ package Paws::JsonParamsService::Method3;
 
   has response => (isa => 'Str', is => 'ro', required => 1);
   has status => (isa => 'Int', is => 'ro', default => 401);
+  has dup_requestid => (isa => 'Bool', is => 'ro', default => 0);
 
   use MooseX::ClassAttribute;
 

--- a/t/lib/TestGivenResponse.pm
+++ b/t/lib/TestGivenResponse.pm
@@ -16,11 +16,10 @@ package TestGivenResponse;
       status  => $call_object->status,
       content => ($call_object->response eq '[UNDEF]' ? undef : $call_object->response),
       headers => {
-        'x-amzn-requestid' => 'fake-uuid',
-        'x-amz-request-id' => 'fake-uuid',
+        'x-amzn-requestid' => ($call_object->dup_requestid ? [ 'fake-uuid', 'fake-uuid' ] : 'fake-uuid' ),
+        'x-amz-request-id' => ($call_object->dup_requestid ? [ 'fake-uuid', 'fake-uuid' ] : 'fake-uuid' ),
       }
     );
-
 
     return $self->caller_to_response($service, $call_object, $response);
   }


### PR DESCRIPTION
Fixes issue #324. Although the only API that seams to be returning duplicate headers is IAM (XML Response), JSON Responses has also been tested and patched to make response handling more robust in the event that AWS sends duplicate request id headers in other services