### PR TITLE
Make HTTP content an empty string by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 0.41
  - V3 signature module has been deprecated, as all APIs use V4 signatures. Dependencies have been removed
+ - Don't pass undef HTTP content to signature modules. At least pass ''. See #325
  - API updates for any service up to the date of release
  - New API: Textract
  - New API: ManagedBlockchain

--- a/lib/Paws/Net/APIRequest.pm
+++ b/lib/Paws/Net/APIRequest.pm
@@ -5,7 +5,7 @@ package Paws::Net::APIRequest;
 
   has parameters => (is => 'rw', isa => 'HashRef', default => sub { {} });
   has headers    => (is => 'rw', isa => 'HTTP::Headers', default => sub { HTTP::Headers->new });
-  has content    => (is => 'rw', isa => 'Str|Undef');
+  has content    => (is => 'rw', isa => 'Str', default => '');
   has method     => (is => 'rw', isa => 'Str');
   has uri        => (is => 'rw', isa => 'Str');
   has url        => (is => 'rw', isa => 'Str');

--- a/t/05_service_calls.t
+++ b/t/05_service_calls.t
@@ -596,7 +596,7 @@ my $mq = $aws->service('MQ');
 
 $request = $mq->ListBrokers;
 
-is($request->content, undef, 'There is no body for a method that doesn\'t have parameters');
+is($request->content, '', 'There is no body for a method that doesn\'t have parameters');
 
 my $r53 = $aws->service('Route53');
 


### PR DESCRIPTION
Fix to solve issue appeared after 0.40 (documented in #325).