### PR TITLE
Fix for issue #171.

### DIFF
--- a/auto-lib/Paws/S3/ListObjectVersions.pm
+++ b/auto-lib/Paws/S3/ListObjectVersions.pm
@@ -12,7 +12,7 @@ package Paws::S3::ListObjectVersions;
   use MooseX::ClassAttribute;
 
   class_has _api_call => (isa => 'Str', is => 'ro', default => 'ListObjectVersions');
-  class_has _api_uri  => (isa => 'Str', is => 'ro', default => '/{Bucket}?versions');
+  class_has _api_uri  => (isa => 'Str', is => 'ro', default => '/{Bucket}?versions=');
   class_has _api_method  => (isa => 'Str', is => 'ro', default => 'GET');
   class_has _returns => (isa => 'Str', is => 'ro', default => 'Paws::S3::ListObjectVersionsOutput');
   class_has _result_key => (isa => 'Str', is => 'ro');


### PR DESCRIPTION
Refer to the call `ListObjectVersions()` at line #378 in `auto-lib/Paws/S3.pm`. This will generate an object of type `Paws::S3::ListObjectsVersion`, see file `auto-lib/Paws/S3/ListObjectVersions.pm`. This object has a field `_api_uri` which is initialized to `/{Bucket}?versions`. Note that the query string of the previous URI does not contain an "=" sign.

Due to a bug (?) in the URI module, a query string without an "=" sign is not considered a query string. 
Unfortunately, this causes `$qparam` to  become empty (i.e. to accidentally delete the `versions` query parameter) at line #218 in `lib/Paws/Net/RestXmlCaller.pm`. Which will later turn the GET request
to the REST API into something other than a `versions` request, and the returned response will not make sense either.

See [Using the REST API](https://docs.aws.amazon.com/AmazonS3/latest/dev/list-obj-version-enabled-bucket.html) for more information on expected format of GET request.