### PR TITLE
Fix travis build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,13 @@ matrix:
     - perl: 5.8
 sudo: false
 before_install:
-  - eval $(curl https://travis-perl.github.io/init) --auto
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
+install:
+  - cpan-install --deps       # installs prereqs, including recommends
+script:
+  - prove -l -j$(test-jobs) $(test-files)   # parallel testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
   allow_failures:
     - perl: dev
     - perl: 5.8
-sudo: false
 before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: perl
+git:
+  submodules: false
 env:
   - IN_TRAVIS=1 AUTHOR_TESTING=1
 perl:


### PR DESCRIPTION
As explained in issue #362 Travis build is broken due a long log output. This is caused by an `auto` mode of  [travis-helpers](https://github.com/travis-perl/helpers). Passing to manual mode as the documentation suggest, makes the build work another time.

More information in the issue mentioned above.
