### PR TITLE
Handle empty arrays in Paws::Net::QueryCaller parameters

### DIFF
--- a/lib/Paws/Net/QueryCaller.pm
+++ b/lib/Paws/Net/QueryCaller.pm
@@ -34,7 +34,9 @@ package Paws::Net::QueryCaller;
             $p{ $key } = $params->{$att};
           }
         } elsif ($att_type =~ m/^ArrayRef\[(.*)\]/) {
-          if (Paws->is_internal_type("$1")){
+	  if (scalar @{ $params->$att } == 0 ) {
+	     $p{ $att } = '';
+	  } elsif (Paws->is_internal_type("$1")){
             my $i = 1;
             foreach my $value (@{ $params->$att }){
               $p{ sprintf($self->array_flatten_string, $key, $i) } = $value;

--- a/t/05_service_calls.t
+++ b/t/05_service_calls.t
@@ -219,6 +219,23 @@ $test_params = {
 request_has_params($test_params, $request);
 
 
+$request = $cfn->CreateStack(
+  StackName => 'MyStack',
+  TemplateBody => '[Template Document]',
+  Tags => [],
+);
+
+
+$test_params = {
+  'StackName' => 'MyStack',
+  'TemplateBody' => '[Template Document]',
+  'Tags' => '',
+};
+
+request_has_params($test_params, $request);
+
+
+
 my $asg = $aws->service('AutoScaling');
 
 $request = $asg->AttachInstances(


### PR DESCRIPTION
This contribution allows passing empty Arrays to calls to AWS services that are using `Paws::Net::QueryCaller` class
This changes should fix issue #376 allowing Paws to clear CloudFormation Stack Tags
