### PR TITLE
Change sentAt from Str to Int

### DIFF
--- a/auto-lib/Paws/PersonalizeEvents/Event.pm
+++ b/auto-lib/Paws/PersonalizeEvents/Event.pm
@@ -3,7 +3,7 @@ package Paws::PersonalizeEvents::Event;
   has EventId => (is => 'ro', isa => 'Str', request_name => 'eventId', traits => ['NameInRequest']);
   has EventType => (is => 'ro', isa => 'Str', request_name => 'eventType', traits => ['NameInRequest'], required => 1);
   has Properties => (is => 'ro', isa => 'Str', request_name => 'properties', traits => ['NameInRequest'], required => 1);
-  has SentAt => (is => 'ro', isa => 'Str', request_name => 'sentAt', traits => ['NameInRequest'], required => 1);
+  has SentAt => (is => 'ro', isa => 'Int', request_name => 'sentAt', traits => ['NameInRequest'], required => 1);
 1;
 
 ### main pod documentation begin ###


### PR DESCRIPTION
sentAt must be of type Int or it will not be serialized correctly. Current implementation causes PutEvents to fail with "class java.lang.String can not be converted to milliseconds since epoch" error.