### PR TITLE
Allow PAUSE to index this distribution much faster

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ allow_dirty = README
 
 [Prereqs::FromCPANfile]
 
+[MetaProvides::Package]
 [MetaYAML]
 [MetaJSON]
 


### PR DESCRIPTION
When a distribution is uploaded to the PAUSE system, it parses every .pm file
for a $VERSION declaration in order to determine the version number to be used 
in the cpan index next to that package name. However, this parsing can be
skipped entirely if data is provided in META.* indicating how to perform the
indexing (as documented at
https://metacpan.org/pod/CPAN::Meta::Spec#provides). A dzil plugin can be used
to insert this metadata using the distribution version.