### PR TITLE
introduce GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: test
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        perl:
+          - "5.34"
+          - "5.32"
+          - "5.30"
+          - "5.28"
+          - "5.26"
+          - "5.24"
+          - "5.22"
+          - "5.20"
+          - "5.18"
+          - "5.16"
+          - "5.14"
+          - "5.12"
+          - "5.10"
+        # on macos-latest, only test with latest version of perl.
+        # because concurrency of builds on macos-latest is limit and it takes long time.
+        include:
+          - os: macos-latest
+            perl: "5.34"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Perl ${{ matrix.perl }}
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+          install-modules-with: cpm
+
+          # develop phase dependencies in cpanfile can't be installed with old perl.
+          # so, we only install modules required by CI here.
+          install-modules-args: --without-develop
+          install-modules: |
+            Template
+            Pod::HTML2Pod
+            Perl::Tidy
+            Carp::Always
+            Devel::Cover
+            Data::Printer
+            Carp::Always
+            Test::Pod
+            Devel::CoverReport
+
+      - name: Test
+        run: prove -l -j2 t
+        env:
+          AUTHOR_TESTING: "1"

--- a/t/13_client_connect_errors.t
+++ b/t/13_client_connect_errors.t
@@ -10,7 +10,7 @@ use lib 't/lib';
 
 use Test::CustomCredentials;
 
-my $match_message_tests = $ENV{IN_TRAVIS} == 1;
+my $match_message_tests = $ENV{CI};
 
 my $closed_server_endpoint = 'http://localhost:65511';
 
@@ -25,7 +25,7 @@ throws_ok {
              )->DescribeInstances;
 } 'Paws::Exception', 'got exception';
 
-like($@->message, qr/Connection refused/, 'Correct message') if ($match_message_tests);
+like($@->message, qr/Connection refused|Operation timed out/, 'Correct message') if ($match_message_tests);
 cmp_ok($@->code, 'eq', 'ConnectionError', 'Correct code ConnectionError code');
 diag "LWP caller";
 
@@ -44,7 +44,7 @@ throws_ok {
                )->DescribeInstances;
 } 'Paws::Exception', 'got exception';
 
-like($@->message, qr/Connection refused/, 'Correct message') if ($match_message_tests);
+like($@->message, qr/Connection refused|Operation timed out/, 'Correct message') if ($match_message_tests);
 cmp_ok($@->code, 'eq', 'ConnectionError', 'Correct code ConnectionError code');
 
 MOJO:
@@ -87,7 +87,7 @@ throws_ok {
                )->DescribeInstances;
 } 'Paws::Exception', 'got exception';
 
-like($@->message, qr/Connection refused/, 'Correct message') if ($match_message_tests);
+like($@->message, qr/Connection refused|Broken pipe/, 'Correct message') if ($match_message_tests);
 cmp_ok($@->code, 'eq', 'ConnectionError', 'Correct code ConnectionError code');
 
 END:

--- a/t/14_dns_client_errors.t
+++ b/t/14_dns_client_errors.t
@@ -10,7 +10,7 @@ use lib 't/lib';
 
 use Test::CustomCredentials;
 
-my $match_message_tests = $ENV{IN_TRAVIS} == 1;
+my $match_message_tests = $ENV{CI};
 
 my $closed_server_endpoint = 'http://unresolvable.example.com';
 
@@ -45,7 +45,7 @@ throws_ok {
                )->DescribeInstances;
 } 'Paws::Exception', 'got exception';
 
-like($@->message, qr/(?:Name or service not known|nodename nor servname provided, or not known)/, 'Correct message') if ($match_message_tests);
+like($@->message, qr/(?:Name or service not known|Bad hostname|nodename nor servname provided, or not known)/, 'Correct message') if ($match_message_tests);
 cmp_ok($@->code, 'eq', 'ConnectionError', 'Correct code ConnectionError code');
 
 MOJO:

--- a/t/15_timeouts.t
+++ b/t/15_timeouts.t
@@ -16,7 +16,7 @@ use IO::Socket::INET;
 # Do a Volkswagen if we are in Travis. Timeout tests are very instable (since
 # when running in Travis, timeouts will usually take more than 61 secs, (probablly
 # due to high loads
-if ($ENV{IN_TRAVIS} == 1 or not defined $ENV{AUTHOR_TESTS}) {
+if ($ENV{TRAVIS} or not defined $ENV{AUTHOR_TESTS}) {
   ok(1, 'Travis CI detected. Skipping timeout tests');
   done_testing;
   exit

--- a/t/28_retries_mojoasynccaller.t
+++ b/t/28_retries_mojoasynccaller.t
@@ -14,7 +14,7 @@ use Test::CustomCredentials;
 
 # Do a Volkswagen if we are in Travis. Timeout tests are very instable (since
 # when running in Travis)
-if ($ENV{IN_TRAVIS} == 1 or not defined $ENV{AUTHOR_TESTS}) {
+if ($ENV{TRAVIS} or not defined $ENV{AUTHOR_TESTS}) {
   ok(1, 'Travis CI detected. Skipping timeout tests');
   done_testing;
   exit


### PR DESCRIPTION
Currently, CI of aws-sdk-perl is running on travis-ci.org https://travis-ci.org/github/pplu/aws-sdk-perl
But Travis-ci.org shut down will occur on May 31, 2021. (ref. https://blog.travis-ci.com/2021-05-07-orgshutdown)
So we should migrate to travis-ci.com or another CI service.

I propose GitHub Actions because it looks that the new plan of travis-ci.com is not OSS friendly.
(ref. https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing)
The new plan provides OSS credits, however we need to contact to travis support team.
And contributors can't use OSS credits on their forked repositories.

On the other hand, all GitHub Users can use GitHub Actions for free on their public repositories.
It makes contributing easier.