### PR TITLE
gen-classes: introduce Parallel::ForkManager for faster gen

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -48,6 +48,7 @@ on 'develop' => sub {
   requires 'Pod::Checker';
   requires 'Pod::Escapes';
   requires 'Data::Munge';
+  requires 'Parallel::ForkManager';
 };
 
 on 'test' => sub {


### PR DESCRIPTION
On my personal system, this cuts `make gen-classes` down from 25 minutes to 7.

There's a lot of options for doing this, my first run just used some arguments to xargs so if you'd prefer something besides Parallel::ForkManager happy to rework it.