### PR TITLE
Fix inconsistent class generation

### DIFF
--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -779,7 +779,7 @@ package Paws::API::Builder {
     foreach my $ex (@{ $self->example_struct->{ $op_name } }) {
       $example_str .= "# $ex->{title}\n";
       if ($ex->{ description }) {
-        local $Text::Wrap::coloumns = 79;
+        local $Text::Wrap::columns = 79;
         local $Text::Wrap::separator = "\n# ";
         $example_str .= '# ' . Text::Wrap::wrap('','',$ex->{ description }) . "\n";
       }

--- a/builder-lib/Paws/API/Builder.pm
+++ b/builder-lib/Paws/API/Builder.pm
@@ -712,7 +712,7 @@ package Paws::API::Builder {
       # Required items first:
       my %struct = ( map { my $sub_shape = $shape->{ members }{$_}{ shape };
                            $_ => [ $self->get_example_code($sub_shape, $cache, $depth+1)] } 
-                     (@{ $shape->{ required } }) );
+                     (sort @{ $shape->{ required } }) );
 
       my $req_struct_str = join("\n", map { "$_  => $struct{$_}[0], " . ($struct{$_}[1] ? "# $struct{$_}[1]" : "") } (sort keys %struct));
 
@@ -720,7 +720,7 @@ package Paws::API::Builder {
       # Followed by optional:
       %struct = ( map { my $sub_shape = $shape->{ members }{$_}{ shape };
                            $_ => [ $self->get_example_code( $sub_shape, $cache, $depth+1, 1 ) ] } 
-                     (@{ $self->optional_params_in_shape( $shape, $cache )} ) );
+                     (sort @{ $self->optional_params_in_shape( $shape, $cache )} ) );
       my $opt_struct_str = join("\n", map { "$_   => $struct{$_}[0], " . ($struct{$_}[1] ? "# $struct{$_}[1]" : "") } (sort keys %struct));
 
 


### PR DESCRIPTION
I'm sure others have noticed that there is a mess of diffs every single time you regenerate the auto-lib directory.  This fixes that inconsistency so the diff of auto-lib actually represents real changes to the generated source and not just a million lines of noisy spacing differences.