### PR TITLE
fix dynamodb retries

### DIFF
--- a/builder-bin/gen_classes.pl
+++ b/builder-bin/gen_classes.pl
@@ -15,6 +15,7 @@ use Parallel::ForkManager;
 use lib 'builder-lib', 't/lib';
 
 use Paws::API::Builder::Paws;
+use Paws::API::Builder::Retry;
 use Paws::API::ServiceToClass;
 
 my $gen_paws_pm    = 0;
@@ -82,6 +83,21 @@ if ($gen_paws_pm) {
       eval {
         my $p = Paws::API::Builder::Paws->new(
           template_path => [ getcwd() . "/templates" ]
+        );
+        $p->process;
+      };
+      my $ret = $@ ? ["$@"] : undef;
+      return $ret;
+    }
+  );
+  $pm->start_child(
+    "Paws/API/Retry.pm",
+    sub {
+      print "Processing Paws/API/Retry.pm\n";
+      eval {
+        my $p = Paws::API::Builder::Retry->new(
+          template_path => [ getcwd() . "/templates" ],
+          retry_definitions_file => "botocore/botocore/data/_retry.json",
         );
         $p->process;
       };

--- a/builder-lib/Paws/API/Builder/Retry.pm
+++ b/builder-lib/Paws/API/Builder/Retry.pm
@@ -1,0 +1,118 @@
+package Paws::API::Builder::Retry {
+  use Template;
+  use autodie;
+  use Path::Class::File;
+  use JSON::MaybeXS;
+  use Moose;
+
+  has retry_definitions_file => (is => 'ro', required => 1);
+  has retry_data => (is => 'ro', lazy => 1, default => sub {
+    my $self = shift;
+    my $file = $self->retry_definitions_file;
+    die "retry_definitions_file ($file) not found" if (not -e $file);
+    my $f = Path::Class::File->new($file);
+    return decode_json($f->slurp);
+  });
+
+  sub generated_retry_rules {
+    my $self = shift;
+    my $data = $self->retry_data;
+
+    my @rules;
+
+    for my $policy (sort keys %{$data->{retry}{__default__}{policies}}) {
+      my $policy_value = $data->{retry}{__default__}{policies}{$policy};
+
+      if (keys %$policy_value == 1 && (keys %$policy_value)[0] eq '$ref') {
+        my $policy_template = $policy_value->{'$ref'};
+        $policy_value = $data->{definitions}{$policy_template};
+        if (!$policy_value) {
+          die "unable to find reference to template $policy_template for default policy $policy";
+        }
+      }
+
+      # validate that we really have a thing that looks like a policy
+      if (!exists $policy_value->{applies_when}) {
+        die "don't understand policy $policy when it doesn't have applies_when";
+      }
+
+      my $applies_when_keys = join(",", sort keys %{$policy_value->{applies_when}});
+
+      push @rules, "# $policy";
+
+      if ($applies_when_keys eq "response") {
+        my $response_keys = join(",", sort keys %{$policy_value->{applies_when}{response}});
+        if ($response_keys eq "http_status_code,service_error_code") {
+          push @rules,
+            sprintf("sub { defined \$_[0]->http_status and \$_[0]->http_status == %d and \$_[0]->code eq \"%s\" },",
+              $policy_value->{applies_when}{response}{http_status_code},
+              quotemeta($policy_value->{applies_when}{response}{service_error_code}));
+        } elsif ($response_keys eq "http_status_code") {
+          push @rules,
+            sprintf("sub { defined \$_[0]->http_status and \$_[0]->http_status == %d },",
+              $policy_value->{applies_when}{response}{http_status_code});
+        } else {
+          die "unsure how to handle $policy and applies_when->response = $response_keys";
+        }
+      } elsif ($applies_when_keys eq "socket_errors") {
+        if (@{$policy_value->{applies_when}{socket_errors}} == 1 &&
+            $policy_value->{applies_when}{socket_errors}[0] eq "GENERAL_CONNECTION_ERROR") {
+          push @rules, "sub { \$_[0]->code eq 'ConnectionError' },";
+        } else {
+          die "unrecognized socket_errors for policy $policy";
+        }
+      }
+    }
+
+    return join("\n", map { (" " x 4) . $_ } @rules);
+  }
+
+  sub save_class {
+    my ($self, $class_name, $content) = @_;
+    return if (not defined $class_name);
+    my @class_parts = split /\:\:/, $class_name;
+    my $class_file_name = "auto-lib/" . ( join '/', @class_parts ) . ".pm";
+    if (0) {#-e $class_file_name) { #not doing this, because there are unimportant differences in files
+      {
+      my $read_content = read_text($class_file_name);
+      die "Non matching for $class_file_name: going to store $content\nvs stored: $read_content" if ($read_content ne $content);
+      }
+    }
+    pop @class_parts;
+    eval { mkdir "auto-lib/" . ( join '/', @class_parts ) };
+    open my $file, ">", $class_file_name;
+    print $file $content;
+    close $file;
+  }
+
+  sub escape_pod {
+    my ($string) = @_;
+    my %char2names = reverse %Pod::Escapes::Name2character;
+    my $rekeys = list2re(keys %char2names);
+    $string =~ s/($rekeys)/E<$char2names{$1}>/g;
+    return $string;
+  }
+
+  has template_path => (is => 'ro', required => 1);
+
+
+
+  sub process_template {
+    my ($self, $template, $vars) = @_;
+    my $tt = Template->new(DEBUG => 1,INCLUDE_PATH => $self->template_path,
+        FILTERS => { escape_pod => \&escape_pod });
+    my $output = '';
+    $tt->process($template, $vars, \$output) || die $tt->error();
+    return $output;
+  }
+
+  sub process {
+    my ($self) = @_;
+    my $class = $self->process_template(
+      'default/paws_api_retry_pm.tt',
+      { c => $self }
+    );
+    $self->save_class('Paws::API::Retry', $class);
+  }
+}
+1;

--- a/templates/default/paws_api_retry_pm.tt
+++ b/templates/default/paws_api_retry_pm.tt
@@ -1,0 +1,89 @@
+package Paws::API::Retry;
+  use Moose;
+  use MooseX::ClassAttribute;
+  use Paws::Exception;
+
+  class_has default_rules => (is => 'ro', isa => 'ArrayRef', default => sub { [
+[% c.generated_retry_rules %]
+  ] });
+
+  has max_tries => (is => 'ro', required => 1);
+  has type => (is => 'ro', required => 1);
+
+  has tries => (is => 'rw', default => 0);
+
+  has retry_rules => (is => 'ro', required => 1);
+
+  has error_for_die => (is => 'rw');
+  has operation_result => (is => 'rw');
+
+  has generator => (is => 'ro');
+
+  around BUILDARGS => sub {
+    my ($orig, $class, %args) = @_;
+
+    if ($args{ type } eq 'exponential') {
+      $args{ generator } = sub {
+        my $self = shift;
+        (2 ** ($self->tries - 2)) + (rand(1) / 2);
+      };
+    } else {
+      die "Don't know how to make a retry type of $args{ type }";
+    }
+
+    return $class->$orig(%args);
+  };
+
+  sub should_retry {
+    my $self = shift;
+    my $res = $self->operation_result;
+
+    if ($self->result_is_exception and $self->_still_has_retries and $self->exception_is_retriable){
+      return 1;
+    }
+    return 0; #Anything not exception should not be retried
+  }
+
+  sub exception_is_retriable {
+    my $self = shift;
+
+    #Try default_rules, and then the Service's retriables
+    foreach my $rule (@{ Paws::API::Retry->default_rules }, @{ $self->retry_rules }){
+      return 1 if ($rule->($self->operation_result));
+    }
+  }
+
+  sub result_is_exception {
+    my $self = shift;
+
+    die "Don't have an operation_result set yet" if (not defined $self->operation_result);
+
+    return 0 if (not ref($self->operation_result));                  # Scalar results
+    return 1 if (ref($self->operation_result) eq 'Paws::Exception'); # Exceptions
+    return 0;                                                        # Rest of objects
+  }
+
+  sub one_more_try {
+    my $self = shift;
+    $self->tries($self->tries + 1);
+  }
+
+  sub sleep_time {
+    my $self = shift;
+    return $self->generator->($self);
+  }
+
+  sub _still_has_retries {
+    my $self = shift;
+    $self->tries < $self->max_tries;
+  }
+
+  sub _is_retriable {
+    my $self = shift;
+    # TODO: evaluate if the error is retriable depending on class definition
+    return 1;
+  }
+
+  __PACKAGE__->meta->make_immutable;
+
+1;


### PR DESCRIPTION
DynamoDB became near unusable due to this commit:

    commit e3dda3a7aa9b37076967c3115d77253ef22445cf
    CommitDate: Tue 02 Jul 2019 11:27:39 AM PDT -0700

        DynamoDB docu update

This is actually because the "ProvisionedThroughputExceededException"
was lifted from being a service-specific retry exception (i.e. in the
dynamodb service json file) to a globally defined
exception (botocore/data/_retry.json).

For the case of dynamodb specifically,
ProvisionedThroughputExceededException is a regular occurrence
especially when using autoscaling so without this change, dynamodb is
practically unusable in Paws!

Also went through and updated Paws::API::Retry with the current list
of retryable exceptions so this also adds gateway timeouts (504), bad
gateway (502), and a couple other 400 errors (Throttled and
ThrottledException vs the normal Throttling and ThrottlingException).

POC script:

    #!/usr/bin/env perl

    use v5.34;
    use warnings;

    use Paws;
    my $paws = Paws->new(
      config => {
        region => 'us-west-2',
        caller => 'Paws::Net::FurlCaller',
      },
    );
    my $ddb = $paws->service('DynamoDB');

    my $i = 0;
    while (1) {
      $i++;
      eval {
        my $item =  $ddb->GetItem(
          TableName => 'low-rsu-table',
          Key => {
            cache_key => { S => 'foobar'.$i },
          }
        );
      };
      if ($@) {
        warn "died after $i items";
        die $@;
      }

    }

Where 'low-rsu-table' is a dynamodb table configured at a low RSU (I
had it set to 1 with autoscaling).  I ran 10 workers of this script
with a hack like: `seq 1 10 | xargs -n1 -P10 perl test-dynamodb.pl`

With 0.43 things started dying near immediately (because it wouldn't
retry on the throughput exceeded exception).

    died after 2 items at test-dynamodb.pl line 27.
    The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.

With this patch it retries like a champ (and I could basically just
leave it running as long as I wanted while seeing tons of throttling
exceptions in the AWS monitoring console).