### PR TITLE
Hold back from latest Mixin::Linewise to support perl v5.10

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,9 @@ requires 'DateTime::Format::ISO8601';
 requires 'URL::Encode';
 requires 'URL::Encode::XS';
 requires 'URI::Template' => '0.23';
+# to support v5.10 we can't drag in a newer of this dependency that Config::INI wants
+# we don't use it directly.
+requires 'Mixin::Linewise' => '< 0.109';
 requires 'Config::INI';
 requires 'Digest::SHA';
 # For the paws CLI


### PR DESCRIPTION
Config::INI wants >= 0.105 but 0.109 requires perl 5.12.