### PR TITLE
Move to Config::AWS to support perl v5.10

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,7 +14,7 @@ requires 'DateTime::Format::ISO8601';
 requires 'URL::Encode';
 requires 'URL::Encode::XS';
 requires 'URI::Template' => '0.23';
-requires 'Config::INI';
+requires 'Config::AWS';
 requires 'Digest::SHA';
 # For the paws CLI
 requires 'DataStruct::Flat';

--- a/lib/Paws/Credential/File.pm
+++ b/lib/Paws/Credential/File.pm
@@ -1,6 +1,6 @@
 package Paws::Credential::File;
   use Moose;
-  use Config::INI::Reader;
+  use Config::AWS qw/read_file/;
   use File::HomeDir;
   use JSON::MaybeXS qw/decode_json/;
   use Paws::Exception;
@@ -26,7 +26,7 @@ package Paws::Credential::File;
     my $self = shift;
     my $ini_file = $self->credentials_file;
     return {} if (not -e $ini_file);
-    my $ini = Config::INI::Reader->read_file($ini_file);
+    my $ini = read_file($ini_file);
     return $ini;
   });
 


### PR DESCRIPTION
Config::INI and specifically its requirement on Mixin::Linewise
require perl v5.12 so let's use Config::AWS instead.  There's actually
some lesser used syntax that Config::INI didn't support anyways:

Given a file like this:

    [profile testing]
    aws_access_key_id = foo
    aws_secret_access_key = bar
    region = us-west-2
    s3 =
      max_concurrent_requests=10
      max_queue_size=1000

Config::AWS (properly) decodes to:

    'testing' => {
      'aws_access_key_id' => 'foo',
      'region' => 'us-west-2',
      's3' => {
        'max_queue_size' => '1000',
        'max_concurrent_requests' => '10'
      },
      'aws_secret_access_key' => 'bar'
    }

whereas Config::INI decodes to:

    'profile testing' => {
      'aws_access_key_id' => 'foo',
      'aws_secret_access_key' => 'bar',
      's3' => '',
      'max_concurrent_requests' => '10',
      'region' => 'us-west-2',
      'max_queue_size' => '1000'
    }

I also suspect that our previous implementation didn't really handle
non-default profiles because it doesn't handle the 'profile ' that is
in the section names.  This should work now on Config::AWS.