### PR TITLE
Support AWS Instance Metadata Service V2 (IMDSv2)

### DIFF
--- a/auto-lib/Paws.pm
+++ b/auto-lib/Paws.pm
@@ -927,6 +927,8 @@ L<Paws::Credential::File> - Gets credentials from AWS SDK config files
 
 L<Paws::Credential::InstanceProfile> - Gets credentials from the InstanceProfile (Role) of the running instance
 
+L<Paws::Credential::InstanceProfile> - Gets credentials from the InstanceProfile (Role) of the running instance using IMDSv2 approach
+
 L<Paws::Credential::STS> - Gets temporary credentials from the Secure Token Service
 
 L<Paws::Credential::AssumeRole> - Gets temporary credentials with AssumeRole

--- a/lib/Paws/Credential/ProviderChain.pm
+++ b/lib/Paws/Credential/ProviderChain.pm
@@ -8,7 +8,9 @@ package Paws::Credential::ProviderChain;
       [ 'Paws::Credential::Environment', 
         'Paws::Credential::File', 
         'Paws::Credential::ECSContainerProfile',
-        'Paws::Credential::InstanceProfile' ]
+        'Paws::Credential::InstanceProfile',
+        'Paws::Credential::InstanceProfileV2',
+      ]
     },
   );
 
@@ -62,6 +64,6 @@ It is the default provider for Paws
 
 =head2 providers: ArrayRef[Str]
 
-Defaults to C<[ 'Paws::Credential::Environment', 'Paws::Credential::File', 'Paws::Credential::InstanceProfile' ]>
+Defaults to C<[ 'Paws::Credential::Environment', 'Paws::Credential::File', 'Paws::Credential::InstanceProfile', 'Paws::Credential::InstanceProfileV2' ]>
 
 =cut

--- a/t/04_credentials.t
+++ b/t/04_credentials.t
@@ -7,6 +7,7 @@ use Paws;
 use Paws::Credential::Explicit;
 use Paws::Credential::Environment;
 use Paws::Credential::InstanceProfile;
+use Paws::Credential::InstanceProfileV2;
 use Paws::Credential::ECSContainerProfile;
 use Paws::Credential::ProviderChain;
 use Paws::Credential::File;
@@ -84,9 +85,32 @@ delete @ENV{qw(
 }
 
 {
+  my $creds = Paws::Credential::InstanceProfileV2->new(ua => Test04::StubUAForMetadata->new(check_header => 1));
+  cmp_ok($creds->access_key, 'eq', 'AK1', 'Access Key 1 (IMDSv2)');
+  cmp_ok($creds->secret_key, 'eq', 'SK1', 'Secret Key 1 (IMDSv2)');
+  cmp_ok($creds->session_token, 'eq', 'TK1', 'Token 1 (IMDSv2)');
+
+  sleep 2;
+
+  cmp_ok($creds->access_key, 'eq', 'AK2', 'Access Key 2 (IMDSv2)');
+  cmp_ok($creds->secret_key, 'eq', 'SK2', 'Secret Key 2 (IMDSv2)');
+  cmp_ok($creds->session_token, 'eq', 'TK2', 'Token 2 (IMDSv2)');
+
+  sleep 2;
+
+  dies_ok { $creds->access_key } 'Exception thrown when garbage arrives (IMDSv2)';
+}
+
+{
   my $creds = Paws::Credential::InstanceProfile->new(ua => Test04::StubUANoMetadata->new);
 
   ok(not($creds->are_set), 'No Creds for no Role');
+}
+
+{
+  my $creds = Paws::Credential::InstanceProfileV2->new(ua => Test04::StubUANoMetadata->new);
+
+  ok(not($creds->are_set), 'No Creds for no Role (IMDSv2)');
 }
 
 {

--- a/t/lib/Test04/StubUAForMetadata.pm
+++ b/t/lib/Test04/StubUAForMetadata.pm
@@ -3,16 +3,19 @@ package Test04::StubUAForMetadata;
 
   has calls => (is => 'rw', isa => 'Int', default => 0, traits => ['Counter'],
                 handles => { increment_calls => 'inc' });
+
+  has check_headers => (is => 'ro', isa => 'Bool', default => 0);
   use DateTime::Format::ISO8601;
 
   sub get {
     my ($self, $url, $args) = @_;
 
-    if ( $url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' && $args->{headers}->{'X-aws-ec2-metadata-token'} eq 'token' ){
+    my $valid_headers = ( $self->check_headers() ) ? $args->{headers}->{'X-aws-ec2-metadata-token'} eq 'token' : 1;
+    if ( $url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' && $valid_headers ){
       return { success => 1, content => "MyRole" };
     }
 
-    if ($url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/MyRole' && $args->{headers}->{'X-aws-ec2-metadata-token'} eq 'token' ) {
+    if ($url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/MyRole' && $valid_headers ) {
       $self->increment_calls;
       if ($self->calls == 1){
         return { success => 1, content => '{"Code" : "Success","LastUpdated" : "2012-04-26T16:39:16Z","Type" : "AWS-HMAC","AccessKeyId" : "AK1","SecretAccessKey" : "SK1","Token" : "TK1","Expiration" : "' . DateTime->now->add(seconds => 241)->iso8601 .'Z"}' };

--- a/t/lib/Test04/StubUAForMetadata.pm
+++ b/t/lib/Test04/StubUAForMetadata.pm
@@ -6,13 +6,13 @@ package Test04::StubUAForMetadata;
   use DateTime::Format::ISO8601;
 
   sub get {
-    my ($self, $url) = @_;
+    my ($self, $url, $args) = @_;
 
-    if ($url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'){
+    if ( $url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' && $args->{headers}->{'X-aws-ec2-metadata-token'} eq 'token' ){
       return { success => 1, content => "MyRole" };
     }
 
-    if ($url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/MyRole') {
+    if ($url eq 'http://169.254.169.254/latest/meta-data/iam/security-credentials/MyRole' && $args->{headers}->{'X-aws-ec2-metadata-token'} eq 'token' ) {
       $self->increment_calls;
       if ($self->calls == 1){
         return { success => 1, content => '{"Code" : "Success","LastUpdated" : "2012-04-26T16:39:16Z","Type" : "AWS-HMAC","AccessKeyId" : "AK1","SecretAccessKey" : "SK1","Token" : "TK1","Expiration" : "' . DateTime->now->add(seconds => 241)->iso8601 .'Z"}' };
@@ -27,6 +27,15 @@ package Test04::StubUAForMetadata;
       } else {
         die "Died on Stub call " . $self->calls;
       }
+    }
+    die "Unknown URL in StubUA $url";
+  }
+
+  sub put {
+    my ($self, $url, $args) = @_;
+
+    if ( $url eq 'http://169.254.169.254/latest/api/token' && exists $args->{headers}->{'X-aws-ec2-metadata-token-ttl-seconds'} ) {
+      return { success => 1, content => 'token' };
     }
     die "Unknown URL in StubUA $url";
   }

--- a/t/lib/Test04/StubUANoMetadata.pm
+++ b/t/lib/Test04/StubUANoMetadata.pm
@@ -8,4 +8,13 @@ package Test04::StubUANoMetadata;
       return { success => 1, content => "" };
     }
   }
+
+  sub put {
+    my ($self, $url, $args) = @_;
+
+    if ( $url eq 'http://169.254.169.254/latest/api/token' && exists $args->{headers}->{'X-aws-ec2-metadata-token-ttl-seconds'} ) {
+      return { success => 1, content => 'token' };
+    }
+    die "Unknown URL in StubUA $url";
+  }
 1;

--- a/templates/default/paws_pm.tt
+++ b/templates/default/paws_pm.tt
@@ -389,6 +389,8 @@ L<Paws::Credential::File> - Gets credentials from AWS SDK config files
 
 L<Paws::Credential::InstanceProfile> - Gets credentials from the InstanceProfile (Role) of the running instance
 
+L<Paws::Credential::InstanceProfileV2> - Gets credentials from the InstanceProfile (Role) of the running instance using IMDSv2 approach
+
 L<Paws::Credential::STS> - Gets temporary credentials from the Secure Token Service
 
 L<Paws::Credential::AssumeRole> - Gets temporary credentials with AssumeRole


### PR DESCRIPTION
Implement support of new version of AWS Instance Metadata Service.
Update calls to be the same as described at the following document:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works