### PR TITLE
Add verify_SSL=>1 to HTTP::Tiny to verify https server identity

### DIFF
--- a/lib/Paws/Credential/ECSContainerProfile.pm
+++ b/lib/Paws/Credential/ECSContainerProfile.pm
@@ -35,6 +35,7 @@ package Paws::Credential::ECSContainerProfile;
       my $self = shift;
       use HTTP::Tiny;
       HTTP::Tiny->new(
+        verify_SSL => 1,
         agent => 'AWS Perl SDK',
         timeout => $self->timeout,
       );

--- a/lib/Paws/Credential/InstanceProfile.pm
+++ b/lib/Paws/Credential/InstanceProfile.pm
@@ -19,6 +19,7 @@ package Paws::Credential::InstanceProfile;
       my $self = shift;
       use HTTP::Tiny;
       HTTP::Tiny->new(
+        verify_SSL => 1,
         agent => 'AWS Perl SDK',
         timeout => $self->timeout,
       );

--- a/lib/Paws/Credential/InstanceProfileV2.pm
+++ b/lib/Paws/Credential/InstanceProfileV2.pm
@@ -25,6 +25,7 @@ package Paws::Credential::InstanceProfileV2;
       my $self = shift;
       use HTTP::Tiny;
       HTTP::Tiny->new(
+        verify_SSL => 1,
         agent => 'AWS Perl SDK',
         timeout => $self->timeout,
       );

--- a/lib/Paws/Net/Caller.pm
+++ b/lib/Paws/Net/Caller.pm
@@ -8,6 +8,7 @@ package Paws::Net::Caller;
     default     => sub {
         use HTTP::Tiny;
         HTTP::Tiny->new(
+          verify_SSL => 1,
           agent => 'AWS Perl SDK ' . $Paws::VERSION,
           timeout => 60,
         );


### PR DESCRIPTION
The `verify_SSL=>1` flag is missing from HTTP::Tiny, and could allow a network attacker to MITM https connections made by this distribution.

Maybe Paws doesn't need certificate verification like [AWS::Lambda](https://github.com/shogo82148/p5-aws-lambda/issues/108) if that's the case I'm sorry for the false alarm. Also, I'm not an AWS customer so haven't been able to test this change.

For more context see: https://hackeriet.github.io/cpan-http-tiny-overview/
