### PR TITLE
make dns tests pass even when there's a proxy configured

### DIFF
--- a/t/13_client_connect_errors.t
+++ b/t/13_client_connect_errors.t
@@ -12,6 +12,11 @@ use Test::CustomCredentials;
 
 my $match_message_tests = $ENV{CI};
 
+# proxies can interfere with this test, because the connection will
+# succeed (to the proxy), the proxy may return some error page, so
+# we're getting InvalidContent instead of ConnectionError
+delete local @ENV{qw(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY)};
+
 my $closed_server_endpoint = 'http://localhost:65511';
 
 my $p = Paws->new(config => { credentials => 'Test::CustomCredentials' });

--- a/t/14_dns_client_errors.t
+++ b/t/14_dns_client_errors.t
@@ -12,6 +12,11 @@ use Test::CustomCredentials;
 
 my $match_message_tests = $ENV{CI};
 
+# proxies can interfere with this test, because the connection will
+# succeed (to the proxy), the proxy may return some error page, so
+# we're getting InvalidContent instead of ConnectionError
+delete local @ENV{qw(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY)};
+
 my $closed_server_endpoint = 'http://unresolvable.example.com';
 
 my $p = Paws->new(config => { credentials => 'Test::CustomCredentials' });

--- a/t/15_timeouts.t
+++ b/t/15_timeouts.t
@@ -22,6 +22,11 @@ my $sock = IO::Socket::INET->new(Listen    => 5,
                                  LocalPort => 9000,
                                  Proto     => 'tcp');
 
+# proxies can interfere with this test, because the connection will
+# succeed (to the proxy), the proxy may return some error page, so
+# we're getting InvalidContent instead of ConnectionError
+delete local @ENV{qw(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY)};
+
 my $closed_server_endpoint = 'http://localhost:9000';
 
 my $p = Paws->new(config => { credentials => 'Test::CustomCredentials' });


### PR DESCRIPTION
as the comment says

a lot of test failures https://www.cpantesters.org/distro/P/Paws.html?oncpan=1&distmat=1&version=0.44&grade=3 are because of this